### PR TITLE
Fix refactor endpoint checks to use urlparse

### DIFF
--- a/utils/api_utils.py
+++ b/utils/api_utils.py
@@ -4,6 +4,7 @@ import logging
 import re
 import requests
 from typing import Dict, Any, List, Union
+from urllib.parse import urlparse
 
 # Set up logger for API utilities
 logger = logging.getLogger(__name__)
@@ -161,23 +162,40 @@ def _get_model_provider(api_endpoint: str) -> str:
     Returns:
         Provider name: "google", "openai", "anthropic", or "default"
     """
-    endpoint_lower = api_endpoint.lower()
-    
-    # Check for Google/Gemini endpoints
-    if "generativelanguage.googleapis.com" in endpoint_lower or "gemini" in endpoint_lower:
+    # Parse the URL and operate on the hostname to avoid substring matches
+    parsed = urlparse(api_endpoint)
+    hostname = (parsed.hostname or "").lower()
+
+    # Fallback: if parsing did not yield a hostname (e.g., bare host string),
+    # use the lowercased input as a heuristic while preserving compatibility.
+    target = hostname or api_endpoint.lower()
+
+    # Check for Google/Gemini endpoints by hostname
+    if (
+        target == "generativelanguage.googleapis.com"
+        or target.endswith(".generativelanguage.googleapis.com")
+        or "gemini" in target
+    ):
         return "google"
-    
-    # Check for OpenAI endpoints
-    elif "api.openai.com" in endpoint_lower or "openai" in endpoint_lower:
+
+    # Check for OpenAI endpoints by hostname
+    if (
+        target == "api.openai.com"
+        or target.endswith(".api.openai.com")
+        or "openai" in target
+    ):
         return "openai"
-    
-    # Check for Anthropic endpoints
-    elif "api.anthropic.com" in endpoint_lower or "anthropic" in endpoint_lower:
+
+    # Check for Anthropic endpoints by hostname
+    if (
+        target == "api.anthropic.com"
+        or target.endswith(".api.anthropic.com")
+        or "anthropic" in target
+    ):
         return "anthropic"
-    
+
     # Default for custom/other providers
-    else:
-        return "default"
+    return "default"
 
 
 def _make_api_request(url: str, headers: dict, data: dict) -> requests.Response:


### PR DESCRIPTION
fix is to parse the URL using `urllib.parse.urlparse` (or `requests.utils.urlparse`) and perform checks on the parsed hostname instead of scanning the entire URL string with `"foo" in endpoint_lower`. We then compare against known hostnames or use suffix checks on the hostname only, avoiding accidental matches in paths, query strings, or attacker-controlled prefixes/suffixes.

Concretely, in `utils/api_utils.py`, update `_get_model_provider` to:

1. Import `urlparse` from `urllib.parse` (at the top of the file, without changing existing imports).
2. In `_get_model_provider`, parse `api_endpoint` using `urlparse(api_endpoint)` and extract `hostname` from the result, lowercasing it.
3. If `hostname` is empty (for example, the caller supplies a bare host string or something malformed), fall back to the existing substring-based heuristic for backward compatibility, but do **not** apply host-based logic to the full URL string when a hostname is available.
4. For each provider, check the hostname using exact match or `.endswith` against known domains, and only then optionally consider additional non-host heuristics:
   - Google: consider as Google if hostname is equal to or ends with `generativelanguage.googleapis.com`, or if hostname contains `gemini`.
   - OpenAI: consider as OpenAI if hostname is equal to or ends with `api.openai.com`, or if hostname contains `openai`.
   - Anthropic: consider as Anthropic if hostname is equal to or ends with `api.anthropic.com`, or if hostname contains `anthropic`.
5. Default to `"default"` if no rule matches.

This preserves the intended behavior (classifying custom or vendor-specific endpoints by name) while ensuring substring matches are applied only to the hostname, not arbitrary URL segments. No new methods are needed beyond the new import and the refactored body of `_get_model_provider`.