### PR TITLE
feat: bump transformers to 5.8.0 to support DeepSeek V4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.20"
+version = "0.1.21"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -31,7 +31,7 @@ classifiers = [
 # Core dependencies that work across all platforms (Mac, Linux, Windows)
 dependencies = [
     "datasets==4.8.4",
-    "transformers==5.6.2",
+    "transformers==5.8.0",
     "trl==1.2.0",
     "wandb==0.26.0",
     "peft==0.19.0",


### PR DESCRIPTION
## Summary

- Bump `transformers==5.6.2` -> `transformers==5.8.0`. DeepSeek V4 (`model_type='deepseek_v4'`) was added upstream in 5.8.0 and is registered in the AutoConfig mapping starting with that release, so `AutoModelForCausalLM.from_pretrained` can now resolve the architecture instead of raising `ValueError: ... does not recognize this architecture`.
- Context: a user-submitted job (`web-submit-4258ab`) using DeepSeek V4 Flash failed in production because the training image shipped `transformers==5.6.2`. Verified locally that 5.8.0 fixes the lookup:

  ```
  transformers 5.8.0
  deepseek_v4 supported: True
  ['deepseek_v2', 'deepseek_v3', 'deepseek_v4', 'deepseek_vl', 'deepseek_vl_hybrid']
  ```

- The unrelated PEFT/LoRA compatibility fix for Gemma 4's `Gemma4ClippableLinear` will follow in a separate PR.

## Test plan

- [ ] CI green (existing suite still passes against `transformers==5.8.0`).
- [ ] Smoke test: CPT LoRA fine-tune on a Qwen3 model (regression check, no behavior change expected).
- [ ] Smoke test: CPT LoRA fine-tune on DeepSeek V4 Flash — confirm `AutoConfig`/`AutoModelForCausalLM` load succeeds and the original `web-submit-4258ab`-style recipe trains.