### PR TITLE
feat: enable LoRA on Gemma 4 (dense + MoE) for PEFT/LoRA

### DIFF
--- a/core/peft_compat.py
+++ b/core/peft_compat.py
@@ -1,0 +1,161 @@
+"""Compatibility shims so PEFT/LoRA can wrap custom Linear-like modules.
+
+Background
+----------
+PEFT 0.19's LoRA dispatcher only accepts targets that are an exact instance
+(or subclass) of ``torch.nn.Linear`` (plus a handful of other known types
+like ``Conv1D``, ``Embedding``, bitsandbytes 4/8-bit linears, etc.). Some
+upstream architectures wrap an internal ``nn.Linear`` inside an
+``nn.Module`` subclass that adds extra behavior — most notably
+``transformers.models.gemma4.modeling_gemma4.Gemma4ClippableLinear``, which
+clamps its output for training stability. PEFT does not recognize that
+class and raises ``ValueError: Target module Gemma4ClippableLinear(...) is
+not supported``.
+
+Strategy
+--------
+For each custom-linear instance, swap it out for ``_LinearShim`` — a thin
+``nn.Linear`` subclass that
+
+1. shares parameters (``weight``/``bias``) with the wrapped module's inner
+   ``nn.Linear`` so PEFT sees real tensors with the correct
+   ``in_features``/``out_features``/dtype, and
+2. delegates ``forward`` back to the original module, so any extra
+   behavior (output clipping for Gemma 4, etc.) is preserved end-to-end.
+   After PEFT wraps the shim as ``lora.Linear.base_layer``, ``base_layer
+   .forward`` is still invoked on every step, so the clamping survives
+   LoRA injection.
+
+Caveats
+-------
+- ``lora.Linear.merge_and_unload`` uses ``base_layer.weight`` directly
+  (not ``base_layer.forward``), so a merged checkpoint loses the clamp.
+  That only matters at export time; training/eval through the adapter
+  preserves the original behavior.
+- If a wrapper class doesn't expose an inner ``nn.Linear`` we can locate,
+  we leave it alone and let PEFT raise its standard error. We don't try
+  to silently no-op the LoRA path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+
+class _LinearShim(nn.Linear):
+    """``nn.Linear``-typed wrapper that delegates forward to a custom module.
+
+    Constructed on the meta device so ``super().__init__`` does not allocate
+    fresh weight memory; the meta parameters are then immediately replaced
+    with the inner linear's real parameters (weight sharing, no copy).
+    """
+
+    def __init__(self, original: nn.Module, inner_linear: nn.Linear):
+        super().__init__(
+            inner_linear.in_features,
+            inner_linear.out_features,
+            bias=inner_linear.bias is not None,
+            device="meta",
+        )
+        # Share parameters with the inner linear. Optimizer/grad updates
+        # therefore reach the same tensor `original` uses on forward.
+        self.weight = inner_linear.weight
+        if inner_linear.bias is not None:
+            self.bias = inner_linear.bias
+        # Register the original module as a child so its buffers/params
+        # (e.g. clipping bounds) follow ``.to()`` and remain in the state
+        # dict. Use a name unlikely to collide with PEFT's target regex.
+        self._fai_inner = original
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self._fai_inner(x)
+
+    def extra_repr(self) -> str:  # pragma: no cover - cosmetic
+        return f"{super().extra_repr()}, wraps={type(self._fai_inner).__name__}"
+
+
+_DEFAULT_PATCH_CLASSES: tuple[str, ...] = ("Gemma4ClippableLinear",)
+
+
+def _find_inner_linear(module: nn.Module) -> Optional[nn.Linear]:
+    """Return the first ``nn.Linear`` descendant of ``module``, or ``None``.
+
+    Direct children are checked first (the common case for wrappers that
+    hold a single inner projection), then a depth-first walk.
+    """
+    for child in module.children():
+        if isinstance(child, nn.Linear) and not isinstance(child, _LinearShim):
+            return child
+    for sub in module.modules():
+        if sub is module:
+            continue
+        if isinstance(sub, nn.Linear) and not isinstance(sub, _LinearShim):
+            return sub
+    return None
+
+
+def patch_custom_linears_for_lora(
+    model: nn.Module,
+    class_names: Iterable[str] = _DEFAULT_PATCH_CLASSES,
+    logger: Optional[logging.Logger] = None,
+) -> int:
+    """Replace recognized custom Linear wrappers with ``_LinearShim``s.
+
+    Args:
+        model: The model to mutate in place.
+        class_names: Class names (by ``type(m).__name__``) to consider for
+            replacement. Defaults to Gemma 4's clippable linear.
+        logger: Optional logger; falls back to the module-level logger.
+
+    Returns:
+        Number of modules successfully replaced.
+    """
+    log = logger or logging.getLogger(__name__)
+    targets = tuple(class_names)
+    if not targets:
+        return 0
+
+    # Collect first, mutate second — avoid invalidating the named_modules
+    # iterator while we replace attributes on parent modules.
+    to_patch: list[tuple[nn.Module, str, nn.Module]] = []
+    for name, sub in model.named_modules():
+        if type(sub).__name__ not in targets:
+            continue
+        if "." in name:
+            parent_name, attr = name.rsplit(".", 1)
+            parent = model.get_submodule(parent_name)
+        else:
+            parent, attr = model, name
+        to_patch.append((parent, attr, sub))
+
+    if not to_patch:
+        return 0
+
+    patched = 0
+    skipped = 0
+    for parent, attr, original in to_patch:
+        inner = _find_inner_linear(original)
+        if inner is None:
+            log.warning(
+                "peft_compat: %s at '%s' has no nn.Linear descendant; "
+                "leaving in place (PEFT will likely reject it).",
+                type(original).__name__,
+                attr,
+            )
+            skipped += 1
+            continue
+        setattr(parent, attr, _LinearShim(original, inner))
+        patched += 1
+
+    log.info(
+        "peft_compat: replaced %d %s module(s) with nn.Linear shim "
+        "for PEFT/LoRA compatibility%s",
+        patched,
+        "/".join(targets),
+        f" (skipped {skipped} without inner Linear)" if skipped else "",
+    )
+    return patched

--- a/core/peft_compat.py
+++ b/core/peft_compat.py
@@ -1,40 +1,68 @@
-"""Compatibility shims so PEFT/LoRA can wrap custom Linear-like modules.
+"""Compatibility helpers so PEFT/LoRA can target Gemma 4 (dense + MoE).
 
-Background
-----------
-PEFT 0.19's LoRA dispatcher only accepts targets that are an exact instance
-(or subclass) of ``torch.nn.Linear`` (plus a handful of other known types
-like ``Conv1D``, ``Embedding``, bitsandbytes 4/8-bit linears, etc.). Some
+This module bundles two independent fixes that together make
+``transformers.models.gemma4`` LoRA-tunable in both dense and MoE flavors.
+Each helper is opt-in and a no-op on models that don't need it, so it's
+safe to call them unconditionally from the training pipeline.
+
+1. ``patch_custom_linears_for_lora`` — custom-Linear wrapper shim
+----------------------------------------------------------------
+PEFT's LoRA dispatcher only accepts targets that are an exact instance
+(or subclass) of ``torch.nn.Linear`` plus a handful of other known types
+(``Conv1D``, ``Embedding``, bitsandbytes 4/8-bit linears, ...). Some
 upstream architectures wrap an internal ``nn.Linear`` inside an
 ``nn.Module`` subclass that adds extra behavior — most notably
-``transformers.models.gemma4.modeling_gemma4.Gemma4ClippableLinear``, which
-clamps its output for training stability. PEFT does not recognize that
-class and raises ``ValueError: Target module Gemma4ClippableLinear(...) is
-not supported``.
+``Gemma4ClippableLinear``, which clamps its output for training
+stability. PEFT does not recognize that class and raises
+``ValueError: Target module Gemma4ClippableLinear(...) is not supported``.
 
-Strategy
---------
-For each custom-linear instance, swap it out for ``_LinearShim`` — a thin
-``nn.Linear`` subclass that
+Fix: swap each instance for ``_LinearShim`` — a thin ``nn.Linear``
+subclass that (a) shares ``weight``/``bias`` with the wrapped module's
+inner ``nn.Linear`` so PEFT sees real tensors with the correct
+``in_features``/``out_features``/dtype, and (b) delegates ``forward``
+back to the original module so the clamp (or any other custom logic)
+survives LoRA injection — PEFT calls ``base_layer.forward`` each step.
 
-1. shares parameters (``weight``/``bias``) with the wrapped module's inner
-   ``nn.Linear`` so PEFT sees real tensors with the correct
-   ``in_features``/``out_features``/dtype, and
-2. delegates ``forward`` back to the original module, so any extra
-   behavior (output clipping for Gemma 4, etc.) is preserved end-to-end.
-   After PEFT wraps the shim as ``lora.Linear.base_layer``, ``base_layer
-   .forward`` is still invoked on every step, so the clamping survives
-   LoRA injection.
+Caveat: ``lora.Linear.merge_and_unload`` reads ``base_layer.weight``
+directly (not ``base_layer.forward``), so a *merged* checkpoint loses
+the clamp. That only matters at export time; training/eval through the
+adapter preserves the original behavior.
 
-Caveats
--------
-- ``lora.Linear.merge_and_unload`` uses ``base_layer.weight`` directly
-  (not ``base_layer.forward``), so a merged checkpoint loses the clamp.
-  That only matters at export time; training/eval through the adapter
-  preserves the original behavior.
-- If a wrapper class doesn't expose an inner ``nn.Linear`` we can locate,
-  we leave it alone and let PEFT raise its standard error. We don't try
-  to silently no-op the LoRA path.
+2. ``extend_lora_config_for_moe_experts`` — MoE expert target injection
+-----------------------------------------------------------------------
+Modern MoE layers (Gemma 4, Qwen3-MoE, Mixtral, ...) store experts as
+stacked 3D ``nn.Parameter`` tensors instead of per-expert ``nn.Linear``
+modules. PEFT ships a dedicated ``ParamWrapper`` LoRA layer for this,
+but it's only dispatched when ``LoraConfig.target_parameters`` includes
+the expert parameter path — either set explicitly or auto-injected by
+PEFT's ``_MOE_TARGET_MODULE_MAPPING`` registry.
+
+That registry (in ``peft.utils.transformers_weight_conversion``) covers
+Mixtral / Qwen2-MoE / Qwen3-MoE but, as of PEFT 0.19, **not** Gemma 4.
+Without this helper, running the standard ``target_modules=[gate_proj,
+up_proj, down_proj]`` recipe against a Gemma 4 MoE model silently
+skips the experts — training "succeeds" but most of the model's
+capacity is never updated.
+
+Fix: walk the model, find every ``Gemma4TextExperts``-shaped module,
+and append its raw expert parameters (``experts.gate_up_proj``,
+``experts.down_proj``) to ``LoraConfig.target_parameters`` so PEFT's
+``ParamWrapper`` kicks in. Also force ``lora_dropout=0.0`` because
+``ParamWrapper`` cannot implement dropout — the math
+``lora_B(lora_A(dropout(x)))`` does not factor out ``x``.
+
+Scope notes
+-----------
+- These helpers target ``Gemma4ClippableLinear`` (Linear-shaped wrapper)
+  and ``Gemma4TextExperts`` (Linear-shaped raw-parameter MoE) by default.
+  Both class names are extensible via parameters on each helper.
+- Models that are already in PEFT's MoE registry (Qwen3-MoE, Mixtral)
+  are unaffected: ``patch_custom_linears_for_lora`` is a no-op when
+  there are no custom wrappers, and the MoE helper's default class
+  allow-list does not include ``Qwen3MoeExperts`` so we don't duplicate
+  work PEFT is already doing.
+- Genuinely non-Linear ops (fused QKV kernels, FP8 quant linears,
+  etc.) are out of scope and need PEFT's own custom-modules API.
 """
 
 from __future__ import annotations
@@ -159,3 +187,107 @@ def patch_custom_linears_for_lora(
         f" (skipped {skipped} without inner Linear)" if skipped else "",
     )
     return patched
+
+
+_DEFAULT_MOE_EXPERT_CLASSES: tuple[str, ...] = ("Gemma4TextExperts",)
+
+
+def extend_lora_config_for_moe_experts(
+    model: nn.Module,
+    lora_config: object,
+    module_class_names: Iterable[str] = _DEFAULT_MOE_EXPERT_CLASSES,
+    logger: Optional[logging.Logger] = None,
+) -> int:
+    """Append MoE expert parameter paths to ``lora_config.target_parameters``.
+
+    PEFT's ``ParamWrapper`` LoRA layer is what makes raw-``nn.Parameter``
+    MoE experts trainable, but it only fires when the expert parameter
+    path appears in ``LoraConfig.target_parameters``. PEFT auto-injects
+    those paths for some architectures (Mixtral, Qwen2-MoE, Qwen3-MoE)
+    via an internal registry — but **not** for Gemma 4 in PEFT 0.19.
+    Without this call, Gemma 4 MoE LoRA training silently leaves the
+    experts frozen.
+
+    This function walks ``model``, finds every submodule whose class
+    name is in ``module_class_names``, and registers each of its
+    directly-owned ``nn.Parameter`` attributes (e.g. ``gate_up_proj``,
+    ``down_proj``) onto ``lora_config.target_parameters`` using a
+    "leaf-attribute.parameter" pattern (e.g. ``experts.gate_up_proj``),
+    which matches every layer's experts at once.
+
+    Side effect: if any expert paths are added and
+    ``lora_config.lora_dropout > 0``, the dropout is forced to ``0.0``
+    with a warning, because PEFT's ``ParamWrapper`` raises if
+    ``lora_dropout != 0`` (the LoRA math ``lora_B(lora_A(dropout(x)))``
+    cannot factor out ``x``).
+
+    Args:
+        model: The model to inspect (not mutated).
+        lora_config: A ``peft.LoraConfig`` instance to update in place.
+        module_class_names: Module class names (by
+            ``type(m).__name__``) considered MoE-expert modules to
+            register. Defaults to ``Gemma4TextExperts`` only —
+            Qwen3-MoE / Mixtral are handled by PEFT's built-in
+            registry, so listing them here would duplicate work.
+        logger: Optional logger; falls back to the module-level logger.
+
+    Returns:
+        Number of new ``target_parameters`` entries appended.
+    """
+    log = logger or logging.getLogger(__name__)
+    targets = tuple(module_class_names)
+    if not targets:
+        return 0
+
+    # Discover patterns like "experts.gate_up_proj" once per (leaf-attr,
+    # param-name) pair. We use the leaf attribute name (last component
+    # of the module's qualified path) so the pattern matches every
+    # layer's experts simultaneously, regardless of layer count.
+    new_patterns: set[str] = set()
+    for qualified_name, sub in model.named_modules():
+        if type(sub).__name__ not in targets:
+            continue
+        if not qualified_name:
+            # An MoE-experts class sitting at the model root would be
+            # extremely unusual; skip rather than guess at a pattern.
+            continue
+        leaf = qualified_name.rsplit(".", 1)[-1]
+        for pname, _ in sub.named_parameters(recurse=False):
+            new_patterns.add(f"{leaf}.{pname}")
+
+    if not new_patterns:
+        return 0
+
+    existing_raw = getattr(lora_config, "target_parameters", None)
+    if existing_raw is None:
+        existing: list[str] = []
+    elif isinstance(existing_raw, str):
+        existing = [existing_raw]
+    else:
+        existing = list(existing_raw)
+
+    added = sorted(new_patterns - set(existing))
+    if not added:
+        return 0
+
+    lora_config.target_parameters = existing + added
+
+    # ParamWrapper does not support lora_dropout != 0.
+    dropout = getattr(lora_config, "lora_dropout", 0.0) or 0.0
+    if dropout > 0.0:
+        log.warning(
+            "peft_compat: forcing lora_dropout %.4f -> 0.0 because PEFT's "
+            "ParamWrapper (used for MoE experts: %s) does not support "
+            "dropout.",
+            dropout,
+            ", ".join(added),
+        )
+        lora_config.lora_dropout = 0.0
+
+    log.info(
+        "peft_compat: registered %d MoE expert parameter pattern(s) "
+        "for LoRA via target_parameters: %s",
+        len(added),
+        ", ".join(added),
+    )
+    return len(added)

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -13,6 +13,7 @@ from transformers import AutoTokenizer
 from peft import LoraConfig, get_peft_model, TaskType, prepare_model_for_kbit_training
 
 from .config import ExperimentConfig
+from .peft_compat import patch_custom_linears_for_lora
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
@@ -269,6 +270,11 @@ class BaseTrainer(ABC):
             except Exception:
                 pass
         
+        # Replace custom Linear wrappers (e.g. Gemma 4's Gemma4ClippableLinear)
+        # with nn.Linear-typed shims so PEFT's LoRA dispatcher accepts them.
+        # No-op for models that use only stock nn.Linear (Qwen3, Llama-3, ...).
+        patch_custom_linears_for_lora(model, logger=self.logger)
+
         # Create LoRA config
         lora_config = LoraConfig(
             r=self.config.model.lora_r,

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -13,7 +13,10 @@ from transformers import AutoTokenizer
 from peft import LoraConfig, get_peft_model, TaskType, prepare_model_for_kbit_training
 
 from .config import ExperimentConfig
-from .peft_compat import patch_custom_linears_for_lora
+from .peft_compat import (
+    extend_lora_config_for_moe_experts,
+    patch_custom_linears_for_lora,
+)
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
@@ -284,7 +287,17 @@ class BaseTrainer(ABC):
             bias=self.config.model.lora_bias,
             task_type=task_type,
         )
-        
+
+        # Register raw-nn.Parameter MoE experts (e.g. Gemma 4's
+        # Gemma4TextExperts.gate_up_proj/down_proj) onto
+        # `lora_config.target_parameters` so PEFT's ParamWrapper actually
+        # LoRA-tunes them. No-op for dense models and for MoE
+        # architectures already covered by PEFT's built-in registry
+        # (Mixtral, Qwen3-MoE, etc.). Forces lora_dropout=0.0 if any
+        # patterns are added, because ParamWrapper can't implement
+        # dropout.
+        extend_lora_config_for_moe_experts(model, lora_config, logger=self.logger)
+
         # Apply LoRA to model
         model = get_peft_model(model, lora_config)
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,15 @@ packages.find = {}
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.json", "*.sh", "*.md"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# `--confcutdir=tests` keeps collection contained to `tests/` so pytest
+# does not walk into the top-level `__init__.py`, which would otherwise
+# trigger a broken transitive import chain (wandb, trl, ...) during
+# collection. `--import-mode=importlib` lets each test module import
+# cleanly without being treated as part of a parent package.
+addopts = "--import-mode=importlib --confcutdir=tests"
+
 [tool.black]
 line-length = 100
 target-version = ['py38', 'py39', 'py310', 'py311']

--- a/tests/test_peft_compat.py
+++ b/tests/test_peft_compat.py
@@ -1,0 +1,179 @@
+"""Tests for ``core.peft_compat``.
+
+Validates that :func:`patch_custom_linears_for_lora`:
+
+1. Reproduces the production bug: PEFT/LoRA refuses
+   ``Gemma4ClippableLinear`` as a target module.
+2. After patching, PEFT can wrap it, the wrapped module preserves the
+   original (clamping) forward behavior, and only LoRA adapter params
+   become trainable.
+3. Is a no-op on models that already use stock ``nn.Linear``.
+4. Safely skips wrappers without a discoverable inner ``nn.Linear``.
+
+No GPU, no real model weights, no HF Hub access required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+pytest.importorskip("peft")
+from peft import LoraConfig, get_peft_model  # noqa: E402
+
+try:
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+    _HAS_GEMMA4 = True
+except Exception:  # pragma: no cover - environment-dependent
+    Gemma4ClippableLinear = None  # type: ignore[assignment]
+    _HAS_GEMMA4 = False
+
+# Load core/peft_compat.py directly so we don't pull in the rest of
+# ``core`` (its ``__init__`` eagerly imports the full trainer stack,
+# including wandb, which we don't need or want for unit tests).
+_PEFT_COMPAT_PATH = Path(__file__).resolve().parents[1] / "core" / "peft_compat.py"
+_spec = importlib.util.spec_from_file_location("peft_compat_under_test", _PEFT_COMPAT_PATH)
+assert _spec is not None and _spec.loader is not None
+_pc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pc)
+patch_custom_linears_for_lora = _pc.patch_custom_linears_for_lora
+_LinearShim = _pc._LinearShim
+
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_GEMMA4,
+    reason="Gemma4ClippableLinear requires transformers>=5.8.0",
+)
+
+
+def _make_tiny_model(use_clipped: bool = True) -> nn.Module:
+    """Tiny model with one ``Gemma4ClippableLinear`` named ``proj``."""
+    cfg = types.SimpleNamespace(use_clipped_linears=use_clipped)
+
+    class Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = Gemma4ClippableLinear(cfg, in_features=8, out_features=4)
+            if use_clipped:
+                # Narrow clamp range so we can detect it numerically.
+                with torch.no_grad():
+                    self.proj.input_min.fill_(-0.5)
+                    self.proj.input_max.fill_(0.5)
+                    self.proj.output_min.fill_(-1.0)
+                    self.proj.output_max.fill_(1.0)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.proj(x)
+
+    return Tiny()
+
+
+def _make_lora() -> LoraConfig:
+    return LoraConfig(r=4, lora_alpha=8, target_modules=["proj"], lora_dropout=0.0)
+
+
+def test_get_peft_model_without_patch_raises() -> None:
+    """Reproduces the production bug: PEFT refuses ``Gemma4ClippableLinear``."""
+    model = _make_tiny_model()
+    with pytest.raises(ValueError, match="Gemma4ClippableLinear"):
+        get_peft_model(model, _make_lora())
+
+
+def test_patch_replaces_with_linear_shim() -> None:
+    model = _make_tiny_model()
+    assert type(model.proj).__name__ == "Gemma4ClippableLinear"
+
+    n = patch_custom_linears_for_lora(model)
+    assert n == 1
+    assert isinstance(model.proj, _LinearShim)
+    # Crucially, the shim is an ``nn.Linear`` subclass so PEFT's
+    # ``isinstance(target, nn.Linear)`` check now succeeds.
+    assert isinstance(model.proj, nn.Linear)
+    # Shape/dtype mirror the inner projection.
+    assert model.proj.in_features == 8
+    assert model.proj.out_features == 4
+
+
+def test_patched_model_preserves_clamp_behavior() -> None:
+    """Forward output must be bitwise-identical after patching.
+
+    Weight/bias are shared with the inner ``nn.Linear`` and the shim's
+    ``forward`` delegates to the original module, so the clamping path
+    is the exact same code.
+    """
+    model = _make_tiny_model()
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 8) * 5.0  # well outside the ±0.5 input clamp
+    y_before = model(x).detach().clone()
+
+    n = patch_custom_linears_for_lora(model)
+    assert n == 1
+
+    y_after = model(x)
+    torch.testing.assert_close(y_after, y_before)
+    # Sanity: output is actually clamped to [-1.0, 1.0].
+    assert y_after.abs().max().item() <= 1.0 + 1e-6
+
+
+def test_get_peft_model_after_patch_succeeds() -> None:
+    model = _make_tiny_model()
+    patch_custom_linears_for_lora(model)
+    peft_model = get_peft_model(model, _make_lora())
+
+    wrapped = peft_model.base_model.model.proj
+    # PEFT must keep our shim as ``base_layer`` — that's what guarantees
+    # the clamp survives every training step (lora.Linear.forward calls
+    # base_layer(x) for the residual).
+    assert isinstance(wrapped.base_layer, _LinearShim)
+
+    total = sum(p.numel() for p in peft_model.parameters())
+    trainable = sum(p.numel() for p in peft_model.parameters() if p.requires_grad)
+    assert 0 < trainable < total
+
+
+def test_patch_is_noop_on_stock_linear() -> None:
+    class Plain(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = nn.Linear(8, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.proj(x)
+
+    model = Plain()
+    n = patch_custom_linears_for_lora(model)
+    assert n == 0
+    assert type(model.proj) is nn.Linear
+
+
+def test_patch_skips_when_no_inner_linear(caplog: pytest.LogCaptureFixture) -> None:
+    """Wrappers without a discoverable inner ``nn.Linear`` are left alone."""
+
+    class FakeWrapper(nn.Module):
+        # Doesn't actually wrap an nn.Linear; class name matches the
+        # allow-list so we exercise the skip branch without depending on
+        # any particular transformers version.
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+    FakeWrapper.__name__ = "Gemma4ClippableLinear"
+
+    class Wrapped(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = FakeWrapper()
+
+    model = Wrapped()
+    with caplog.at_level("WARNING"):
+        n = patch_custom_linears_for_lora(model)
+    assert n == 0
+    # Original module untouched.
+    assert type(model.proj).__name__ == "Gemma4ClippableLinear"
+    assert any("no nn.Linear descendant" in rec.message for rec in caplog.records)

--- a/tests/test_peft_compat.py
+++ b/tests/test_peft_compat.py
@@ -1,14 +1,28 @@
 """Tests for ``core.peft_compat``.
 
-Validates that :func:`patch_custom_linears_for_lora`:
+Covers both fixes:
 
-1. Reproduces the production bug: PEFT/LoRA refuses
-   ``Gemma4ClippableLinear`` as a target module.
-2. After patching, PEFT can wrap it, the wrapped module preserves the
-   original (clamping) forward behavior, and only LoRA adapter params
-   become trainable.
-3. Is a no-op on models that already use stock ``nn.Linear``.
-4. Safely skips wrappers without a discoverable inner ``nn.Linear``.
+A. :func:`patch_custom_linears_for_lora`
+
+   1. Reproduces the production bug: PEFT/LoRA refuses
+      ``Gemma4ClippableLinear`` as a target module.
+   2. After patching, PEFT can wrap it, the wrapped module preserves
+      the original (clamping) forward behavior, and only LoRA adapter
+      params become trainable.
+   3. Is a no-op on models that already use stock ``nn.Linear``.
+   4. Safely skips wrappers without a discoverable inner ``nn.Linear``.
+
+B. :func:`extend_lora_config_for_moe_experts`
+
+   5. Reproduces the latent Gemma 4 MoE bug: with the standard
+      ``target_modules`` recipe and no ``target_parameters``, PEFT
+      silently skips the experts (zero ``ParamWrapper`` instances).
+   6. After the helper runs, PEFT creates one ``ParamWrapper`` per
+      expert parameter per layer, and trainable param count grows
+      meaningfully because the experts now have adapters.
+   7. The helper forces ``lora_dropout`` to ``0.0`` (with a warning)
+      because ``ParamWrapper`` cannot implement dropout.
+   8. Is a no-op on models without MoE experts.
 
 No GPU, no real model weights, no HF Hub access required.
 """
@@ -34,6 +48,14 @@ except Exception:  # pragma: no cover - environment-dependent
     Gemma4ClippableLinear = None  # type: ignore[assignment]
     _HAS_GEMMA4 = False
 
+try:
+    from transformers import Gemma4ForCausalLM, Gemma4TextConfig
+    _HAS_GEMMA4_MODEL = True
+except Exception:  # pragma: no cover - environment-dependent
+    Gemma4ForCausalLM = None  # type: ignore[assignment]
+    Gemma4TextConfig = None  # type: ignore[assignment]
+    _HAS_GEMMA4_MODEL = False
+
 # Load core/peft_compat.py directly so we don't pull in the rest of
 # ``core`` (its ``__init__`` eagerly imports the full trainer stack,
 # including wandb, which we don't need or want for unit tests).
@@ -43,6 +65,7 @@ assert _spec is not None and _spec.loader is not None
 _pc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_pc)
 patch_custom_linears_for_lora = _pc.patch_custom_linears_for_lora
+extend_lora_config_for_moe_experts = _pc.extend_lora_config_for_moe_experts
 _LinearShim = _pc._LinearShim
 
 
@@ -177,3 +200,135 @@ def test_patch_skips_when_no_inner_linear(caplog: pytest.LogCaptureFixture) -> N
     # Original module untouched.
     assert type(model.proj).__name__ == "Gemma4ClippableLinear"
     assert any("no nn.Linear descendant" in rec.message for rec in caplog.records)
+
+
+# --------------------------------------------------------------------- #
+# MoE expert target injection (extend_lora_config_for_moe_experts)
+# --------------------------------------------------------------------- #
+
+
+def _tiny_gemma4_moe_model() -> nn.Module:
+    """A tiny but real Gemma 4 ``ForCausalLM`` with the MoE block enabled."""
+    cfg = Gemma4TextConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        global_head_dim=8,
+        hidden_size_per_layer_input=8,
+        layer_types=["sliding_attention", "full_attention"],
+        enable_moe_block=True,
+        num_experts=2,
+        num_experts_per_tok=1,
+        num_local_experts=2,
+    )
+    torch.manual_seed(0)
+    return Gemma4ForCausalLM(cfg)
+
+
+def _count_lora_layer_types(peft_model: nn.Module) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for _, mod in peft_model.named_modules():
+        name = type(mod).__name__
+        if "lora" in name.lower() or "Param" in name:
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+@pytest.mark.skipif(
+    not _HAS_GEMMA4_MODEL, reason="Gemma4ForCausalLM requires transformers>=5.8.0"
+)
+def test_get_peft_model_silently_skips_gemma4_experts_without_helper() -> None:
+    """Pins the latent bug — without the helper, Gemma 4 experts are not LoRA'd."""
+    model = _tiny_gemma4_moe_model()
+    lora = LoraConfig(
+        r=4,
+        lora_alpha=8,
+        lora_dropout=0.0,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+    )
+    from peft import get_peft_model as _gpm
+    peft_model = _gpm(model, lora)
+    counts = _count_lora_layer_types(peft_model)
+    # PEFT 0.19 does not register Gemma 4 in `_MOE_TARGET_MODULE_MAPPING`,
+    # so zero `ParamWrapper`s should be created.
+    assert counts.get("ParamWrapper", 0) == 0
+
+
+@pytest.mark.skipif(
+    not _HAS_GEMMA4_MODEL, reason="Gemma4ForCausalLM requires transformers>=5.8.0"
+)
+def test_extend_lora_config_registers_gemma4_experts() -> None:
+    """After the helper runs, PEFT creates a ParamWrapper per expert param per layer."""
+    model = _tiny_gemma4_moe_model()
+    lora = LoraConfig(
+        r=4,
+        lora_alpha=8,
+        lora_dropout=0.0,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+    )
+
+    added = extend_lora_config_for_moe_experts(model, lora)
+
+    # 2 expert params (gate_up_proj, down_proj) collapse to 2 patterns
+    # via the leaf-attribute-name aggregation: "experts.gate_up_proj"
+    # and "experts.down_proj".
+    assert added == 2
+    assert set(lora.target_parameters) == {"experts.gate_up_proj", "experts.down_proj"}
+
+    peft_model = get_peft_model(model, lora)
+    counts = _count_lora_layer_types(peft_model)
+    # 2 expert params x 2 layers = 4 ParamWrappers.
+    assert counts.get("ParamWrapper", 0) == 4
+
+    # Trainable params should now meaningfully exceed what we'd get
+    # without the helper. We don't pin an exact number, only the
+    # qualitative property: there must be LoRA on the experts.
+    trainable = sum(p.numel() for p in peft_model.parameters() if p.requires_grad)
+    assert trainable > 0
+
+
+@pytest.mark.skipif(
+    not _HAS_GEMMA4_MODEL, reason="Gemma4ForCausalLM requires transformers>=5.8.0"
+)
+def test_extend_lora_config_forces_dropout_to_zero(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """ParamWrapper rejects lora_dropout > 0; the helper must clamp to 0 with a warning."""
+    model = _tiny_gemma4_moe_model()
+    lora = LoraConfig(r=4, lora_alpha=8, lora_dropout=0.1)
+
+    with caplog.at_level("WARNING"):
+        added = extend_lora_config_for_moe_experts(model, lora)
+
+    assert added > 0
+    assert lora.lora_dropout == 0.0
+    assert any("lora_dropout" in rec.message for rec in caplog.records)
+
+
+def test_extend_lora_config_is_noop_when_no_moe_experts() -> None:
+    """A model with no MoE-expert modules should not get any target_parameters appended."""
+
+    class Plain(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = nn.Linear(8, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.proj(x)
+
+    model = Plain()
+    lora = LoraConfig(r=4, lora_alpha=8, target_modules=["proj"], lora_dropout=0.1)
+
+    added = extend_lora_config_for_moe_experts(model, lora)
+
+    assert added == 0
+    # No experts found, so dropout must be left untouched.
+    assert lora.lora_dropout == 0.1
+    assert not lora.target_parameters


### PR DESCRIPTION
## Summary

`core/peft_compat.py` now bundles two independent, opt-in fixes that together let FAI-RL LoRA-tune the full Gemma 4 family (dense `gemma4-31b`, MoE `gemma4-26b-a4b-it`, and the multimodal vision/audio encoders if anyone reaches for them). Each helper is a no-op on models that don't need it, so the trainer can call them unconditionally for every recipe.

### Fix A — `patch_custom_linears_for_lora` (custom Linear shim)

Replaces `Gemma4ClippableLinear` (and any future allow-listed `nn.Linear`-shaped wrapper) with `_LinearShim`, an `nn.Linear` subclass that (a) shares `weight`/`bias` with the wrapped module's inner Linear so PEFT sees the correct shapes/dtype and (b) delegates `forward` back to the original module so output clamping survives LoRA injection. Without this, `get_peft_model` raises `ValueError: Target module Gemma4ClippableLinear(...) is not supported` at LoRA injection.

### Fix B — `extend_lora_config_for_moe_experts` (MoE expert target injection)

Gemma 4's MoE block stores experts as stacked 3D `nn.Parameter`s on `Gemma4TextExperts` rather than per-expert `nn.Linear` modules. PEFT ships a `ParamWrapper` LoRA layer that handles this, but it only fires when the parameter path appears in `LoraConfig.target_parameters` — either explicitly, or via PEFT's `_MOE_TARGET_MODULE_MAPPING` registry. As of PEFT 0.19, **`gemma4` / `gemma4_text` are not in that registry**, so the standard `target_modules=[gate_proj, up_proj, down_proj]` recipe silently leaves the experts frozen. Training "succeeds" but most of the model's capacity is never updated.

The new helper walks the model, finds every `Gemma4TextExperts`-shaped submodule, and appends its raw `nn.Parameter` attributes (`experts.gate_up_proj`, `experts.down_proj`) to `lora_config.target_parameters`. PEFT's `ParamWrapper` then fires on every layer's experts.

`ParamWrapper` rejects `lora_dropout != 0` (the math `lora_B(lora_A(dropout(x)))` does not factor out `x`), so the helper forces `lora_dropout=0.0` with a warning whenever expert patterns are added — matching the constraint already documented in `qwen3_30B_A3B_lora.yaml`.

### Wiring

`BaseTrainer._setup_lora` (or equivalent) now calls, in order:
1. `patch_custom_linears_for_lora(model)` — no-op for stock-`nn.Linear` models.
2. Build `LoraConfig`.
3. `extend_lora_config_for_moe_experts(model, lora_config)` — no-op for non-MoE / already-covered MoE models.
4. `get_peft_model(model, lora_config)`.

### Scope notes

- The MoE helper's default allow-list is `("Gemma4TextExperts",)` only. Qwen3-MoE / Mixtral / Qwen2-MoE are already covered by PEFT's built-in registry; listing them here would duplicate work PEFT is already doing.
- Genuinely non-Linear ops (fused QKV kernels, FP8 / bnb linears, etc.) are out of scope and need PEFT's own custom-modules API.

## Test plan

Ten unit tests in `tests/test_peft_compat.py`, all CPU-only, ~2s total:

**Fix A — shim:**
- `test_get_peft_model_without_patch_raises` — pins the bug (`ValueError` matching `Gemma4ClippableLinear`).
- `test_patch_replaces_with_linear_shim` — swap happens, shim is `nn.Linear` subclass with correct shape.
- `test_patched_model_preserves_clamp_behavior` — bitwise-identical forward output, clamp preserved.
- `test_get_peft_model_after_patch_succeeds` — end-to-end LoRA wrap, `base_layer is _LinearShim`.
- `test_patch_is_noop_on_stock_linear` — regression guard.
- `test_patch_skips_when_no_inner_linear` — exercises the warning path for wrappers without an inner Linear.

**Fix B — MoE expert injection** (use a tiny real `Gemma4ForCausalLM` with `enable_moe_block=True`):
- `test_get_peft_model_silently_skips_gemma4_experts_without_helper` — pins the latent bug: zero `ParamWrapper`s without our helper.
- `test_extend_lora_config_registers_gemma4_experts` — helper adds `experts.gate_up_proj` and `experts.down_proj` to `target_parameters`; PEFT then creates one `ParamWrapper` per expert param per layer.
- `test_extend_lora_config_forces_dropout_to_zero` — `lora_dropout` clamped to 0 with a warning when expert patterns are added.
- `test_extend_lora_config_is_noop_when_no_moe_experts` — no-op on dense models, `lora_dropout` left untouched.

Pyproject pytest block (`testpaths = ["tests"]`, `--import-mode=importlib --confcutdir=tests`) keeps collection contained so plain `pytest` works on a fresh checkout without tripping on the top-level `__init__.py`.

## Smoke-test follow-ups (out of band)

- [ ] CPT LoRA on `gemma4-31b` (dense) — confirm no behavior change vs. pre-PR baseline.
- [ ] CPT LoRA on `gemma4-26b-a4b-it` (MoE) — confirm expert params show up in the trainable-param count and loss converges.
- [ ] Qwen3-30B-A3B regression — confirm PEFT's built-in MoE path still works untouched (the helper's default allow-list excludes Qwen3 experts).