### PR TITLE
load fine-tuned model from S3 as training base for cascading training

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -29,6 +29,11 @@ class ModelConfig:
     bnb_4bit_quant_type: str = "nf4"
     bnb_4bit_use_double_quant: bool = True
     
+    # S3 connection overrides (only used when base_model_name starts with s3://).
+    # When unset, boto3 uses its default credential/region resolution chain.
+    s3_region: Optional[str] = None
+    s3_endpoint_url: Optional[str] = None
+
     # LoRA configuration
     use_lora: bool = False
     lora_r: int = 8
@@ -49,6 +54,8 @@ class ModelConfig:
             "bnb_4bit_compute_dtype": self.bnb_4bit_compute_dtype,
             "bnb_4bit_quant_type": self.bnb_4bit_quant_type,
             "bnb_4bit_use_double_quant": self.bnb_4bit_use_double_quant,
+            "s3_region": self.s3_region,
+            "s3_endpoint_url": self.s3_endpoint_url,
             "use_lora": self.use_lora,
             "lora_r": self.lora_r,
             "lora_alpha": self.lora_alpha,

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -19,7 +19,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from utils.logging_utils import setup_logging, SafeLogger
-from utils.s3_utils import build_s3_callback
+from utils.s3_utils import build_s3_callback, download_directory_from_s3
 from utils.device_utils import (
     get_device_type,
     is_cuda_available,
@@ -51,9 +51,14 @@ class BaseTrainer(ABC):
         
         # Adapt config for the current device (handles MPS/CPU limitations)
         self.config = adapt_config_for_device(self.config)
-        
+
         self.local_rank = int(os.environ.get("LOCAL_RANK", -1))
         self.is_main_process = self.local_rank == -1 or self.local_rank == 0
+
+        # Download model from S3 if base_model_name is an s3:// URI. This must
+        # happen before setup_model() so all trainers transparently get a local
+        # path. Rank 0 (per-node) downloads; other ranks wait on a sentinel file.
+        self._maybe_download_s3_model()
 
         # Set device for distributed training
         if self.local_rank != -1:
@@ -75,6 +80,64 @@ class BaseTrainer(ABC):
         # Set memory optimization for CUDA
         if is_cuda_available():
             os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+    def _maybe_download_s3_model(self) -> None:
+        """Download the base model from S3 if base_model_name is an s3:// URI.
+
+        On each node, local rank 0 performs the download into a deterministic
+        cache directory under the system temp dir.  Other local ranks busy-wait
+        on a sentinel file written by rank 0 once the download completes.
+        Subsequent runs on the same node reuse the cached directory, so the
+        download only happens once per node per unique S3 URI.
+
+        After this method returns, self.config.model.base_model_name points to
+        a local directory that AutoModelForCausalLM.from_pretrained() can load.
+        """
+        import hashlib
+        import tempfile
+        import time
+
+        model_name = self.config.model.base_model_name
+        if not model_name.startswith("s3://"):
+            return
+
+        uri_hash = hashlib.md5(model_name.encode()).hexdigest()[:12]
+        cache_dir = os.path.join(tempfile.gettempdir(), f"fai-rl-model-{uri_hash}")
+        sentinel = os.path.join(cache_dir, ".download_complete")
+
+        region = getattr(self.config.model, "s3_region", None)
+        endpoint_url = getattr(self.config.model, "s3_endpoint_url", None)
+
+        if self.local_rank <= 0:
+            # local_rank=-1 (single GPU) or local_rank=0 (first GPU per node)
+            if not os.path.exists(sentinel):
+                self.logger.info("Downloading model from %s -> %s", model_name, cache_dir)
+                download_directory_from_s3(
+                    model_name,
+                    cache_dir,
+                    region=region,
+                    endpoint_url=endpoint_url,
+                )
+                open(sentinel, "w").close()
+                self.logger.info("Model download complete, cached at %s", cache_dir)
+            else:
+                self.logger.info("Reusing cached model at %s", cache_dir)
+        else:
+            # Non-zero local ranks wait for rank 0 to finish downloading.
+            self.logger.info(
+                "Local rank %d waiting for model download by rank 0...", self.local_rank
+            )
+            timeout = 3600
+            elapsed = 0
+            while not os.path.exists(sentinel):
+                time.sleep(5)
+                elapsed += 5
+                if elapsed >= timeout:
+                    raise TimeoutError(
+                        f"Timed out after {timeout}s waiting for S3 model download at {cache_dir}"
+                    )
+
+        self.config.model.base_model_name = cache_dir
 
     def setup_wandb(self):
         """Initialize Weights & Biases logging."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.22"
+version = "0.1.23"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.21"
+version = "0.1.22"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/README.md
+++ b/recipes/training/README.md
@@ -19,13 +19,14 @@ YAML configuration files for all supported training algorithms. Each recipe is a
 
 ### SFT (Supervised Fine-Tuning)
 
-| Recipe | Dataset source | Notes |
-|--------|---------------|-------|
-| `sft/llama3_3B_lora.yaml` | HuggingFace Hub | LoRA, Llama-3.2-3B |
-| `sft/llama3_3B_qlora.yaml` | HuggingFace Hub | QLoRA (4-bit), Llama-3.2-3B |
-| `sft/llama3_3B_full.yaml` | HuggingFace Hub | Full fine-tune, Llama-3.2-3B |
-| `sft/llama3_3B_local_file.yaml` | Local file | `.jsonl/.json/.csv/.parquet` |
-| `sft/llama3_3B_s3_file.yaml` | S3 | `s3://bucket/key.jsonl` |
+| Recipe | Dataset source | Model source | Notes |
+|--------|---------------|--------------|-------|
+| `sft/llama3_3B_lora.yaml` | HuggingFace Hub | HuggingFace Hub | LoRA, Llama-3.2-3B |
+| `sft/llama3_3B_qlora.yaml` | HuggingFace Hub | HuggingFace Hub | QLoRA (4-bit), Llama-3.2-3B |
+| `sft/llama3_3B_full.yaml` | HuggingFace Hub | HuggingFace Hub | Full fine-tune, Llama-3.2-3B |
+| `sft/llama3_3B_local_file.yaml` | Local file | HuggingFace Hub | `.jsonl/.json/.csv/.parquet` |
+| `sft/llama3_3B_s3_file.yaml` | S3 | HuggingFace Hub | `s3://bucket/key.jsonl` |
+| `sft/llama3_3B_s3_model.yaml` | S3 | S3 | Continue training from fine-tuned model in S3 |
 
 ### DPO (Direct Preference Optimization)
 
@@ -62,6 +63,18 @@ YAML configuration files for all supported training algorithms. Each recipe is a
 | `gspo/llama3_3B_full.yaml` | HuggingFace Hub | Full fine-tune, Llama-3.2-3B |
 | `gspo/llama3_3B_local_file.yaml` | Local file | `.jsonl/.json/.csv/.parquet` |
 | `gspo/llama3_3B_s3_file.yaml` | S3 | `s3://bucket/key.jsonl` |
+
+## Model Sources
+
+`model.base_model_name` accepts three formats. The source is selected automatically by its prefix:
+
+| Source | `base_model_name` value | Example |
+|--------|------------------------|---------|
+| HuggingFace Hub | Hub model ID | `"meta-llama/Llama-3.2-3B-Instruct"` |
+| Local directory | Absolute or relative path | `"/checkpoints/my-model"` |
+| S3 | `s3://` URI pointing to a model directory | `"s3://my-bucket/checkpoints/run-v1/final"` |
+
+When an `s3://` URI is given, the trainer downloads the model directory to a local cache before calling `from_pretrained()`. The cache is keyed on the URI so repeated runs on the same node skip the download.
 
 ## Dataset Sources
 
@@ -104,9 +117,35 @@ fai-rl-train --recipe recipes/training/sft/llama3_3B_local_file.yaml --num-gpus 
 # Use an S3 file
 fai-rl-train --recipe recipes/training/sft/llama3_3B_s3_file.yaml --num-gpus 1 \
   data.datasets[0].name=s3://my-bucket/datasets/train.jsonl
+
+# Continue training from a fine-tuned model stored in S3
+fai-rl-train --recipe recipes/training/sft/llama3_3B_s3_model.yaml --num-gpus 4 \
+  model.base_model_name=s3://my-bucket/checkpoints/run-v1/final \
+  data.datasets[0].name=s3://my-bucket/datasets/train-v2.jsonl \
+  training.output_dir=models/my_model_v2
 ```
 
 > Running from the repo directly: replace `fai-rl-train` with `python trainers/train.py`.
+
+## S3 Model Loading
+
+Set `base_model_name` to an `s3://` URI that points to a model directory — typically the `final/` prefix written by the S3 upload callback after a previous training run. AWS credentials are resolved from the standard boto3 chain (IAM role, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `~/.aws/credentials`).
+
+```yaml
+model:
+  base_model_name: "s3://my-bucket/checkpoints/run-v1/final"
+  s3_region: null        # override AWS region if needed
+  s3_endpoint_url: null  # set for MinIO or other S3-compatible stores
+```
+
+**Download behavior:**
+- On each node, local rank 0 downloads the model directory to `/tmp/fai-rl-model-<hash>/` and writes a sentinel file when done. Non-zero local ranks wait on the sentinel, then all ranks load from the shared local path.
+- The cache is keyed on the S3 URI, so subsequent runs on the same node skip the download.
+- Both s5cmd (fast, ~1.25 GiB/s) and boto3 (fallback) are supported — s5cmd is used automatically if it is on `$PATH`.
+
+**Continuing from a LoRA checkpoint:**
+
+The S3 callback saves LoRA adapter files (`adapter_config.json`, `adapter_model.safetensors`) when `save_only_model: true`. These can be loaded as `base_model_name` for the next training round — HuggingFace PEFT merges the adapter automatically on load.
 
 ## S3 Dataset Loading
 
@@ -135,4 +174,5 @@ Variants:
   full          Full parameter fine-tuning
   local_file    Local dataset file (.jsonl / .json / .csv / .parquet)
   s3_file       S3 dataset file (s3://bucket/key.ext)
+  s3_model      S3 base model + S3 dataset (continue from fine-tuned checkpoint)
 ```

--- a/recipes/training/sft/llama3_3B_s3_model.yaml
+++ b/recipes/training/sft/llama3_3B_s3_model.yaml
@@ -1,0 +1,97 @@
+# SFT recipe that continues training from a fine-tuned model stored in S3.
+#
+# Set base_model_name to an s3:// URI pointing to a previously uploaded model
+# directory (e.g. the "final/" prefix written by the S3UploadCallback).  The
+# trainer downloads it to a local cache on each node before loading, so
+# AutoModelForCausalLM.from_pretrained() receives a plain local path.
+#
+# Usage:
+#   python trainers/train.py --recipe recipes/training/sft/llama3_3B_s3_model.yaml
+
+# Model Configuration
+model:
+  base_model_name: "s3://your-bucket/checkpoints/run-v1/final"  # S3 URI to fine-tuned model dir
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_8bit: false
+  load_in_4bit: false
+  use_flash_attention: false
+  # S3 connection overrides for the model download (null = use AWS default chain)
+  s3_region: null
+  s3_endpoint_url: null
+
+  # LoRA configuration
+  use_lora: true
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - q_proj
+    - v_proj
+    - k_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
+  lora_bias: "none"
+
+# Data Configuration
+data:
+  datasets:
+    - name: "s3://your-bucket/datasets/train.jsonl"
+      prompt_column: "prompt"
+      dataset_columns: ["prompt", "response"]
+      s3_region: null
+      s3_endpoint_url: null
+
+  max_length: 2048
+  max_prompt_length: 1024
+  remove_unused_columns: false
+
+  system_prompt: |
+    {prompt}
+
+# Training Configuration
+training:
+  algorithm: "sft"
+  output_dir: "models/llama3-3B-inst-sft-s3-model-v2"
+
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 16
+  learning_rate: 5.0e-5
+  num_train_epochs: 1
+  max_steps: -1
+  warmup_steps: 50
+
+  logging_steps: 5
+  save_steps: 50
+  eval_steps: 50
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true
+
+  dataloader_num_workers: 0
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+
+# Weights & Biases Integration
+wandb:
+  enabled: false
+  project: "your-project"
+  entity: "your-wandb-entity"
+  name: "Llama-3.2-3B-Inst-LoRA-SFT-from-s3-model"
+  tags: ["SFT", "llama3", "3B-Inst", "LoRA", "s3-model"]
+  api_key: null
+  base_url: "https://api.wandb.ai"
+
+# S3 Checkpoint Upload
+s3:
+  enabled: false
+  bucket: "your-s3-bucket"
+  prefix: "checkpoints/llama3-3B-inst-sft-s3-model-v2"
+  region: null
+  endpoint_url: null
+  upload_checkpoints: true
+  upload_final_model: true
+  delete_local_after_upload: false

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -217,6 +217,67 @@ class S3UploadCallback(TrainerCallback):
         logger.info("All S3 uploads finished.")
 
 
+def download_directory_from_s3(
+    s3_uri: str,
+    local_dir: str,
+    region: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    downloader: str = "auto",
+) -> None:
+    """Download all objects under an S3 prefix to *local_dir*.
+
+    The directory structure under the prefix is preserved. *downloader* selects
+    the backend ("auto" picks s5cmd if installed, else boto3).
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(s3_uri)
+    if parsed.scheme != "s3":
+        raise ValueError(f"Expected s3:// URI, got: {s3_uri!r}")
+
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip("/").rstrip("/")
+
+    os.makedirs(local_dir, exist_ok=True)
+
+    backend = _resolve_uploader(downloader)
+    logger.info(
+        "Downloading s3://%s/%s -> %s (backend=%s)", bucket, prefix, local_dir, backend
+    )
+
+    if backend == "s5cmd":
+        argv = ["s5cmd"]
+        if endpoint_url:
+            argv.extend(["--endpoint-url", endpoint_url])
+        # s5cmd sync handles recursive directory copies efficiently
+        argv.extend(["sync", f"s3://{bucket}/{prefix}/", f"{local_dir}/"])
+        env = os.environ.copy()
+        if region and "AWS_REGION" not in env and "AWS_DEFAULT_REGION" not in env:
+            env["AWS_REGION"] = region
+        result = subprocess.run(argv, env=env, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"s5cmd download failed (exit {result.returncode}): {result.stderr.strip()}"
+            )
+    else:
+        client = _get_s3_client(region, endpoint_url)
+        paginator = client.get_paginator("list_objects_v2")
+        total = 0
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix + "/"):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                relative = key[len(prefix):].lstrip("/")
+                if not relative:
+                    continue
+                local_file = os.path.join(local_dir, relative)
+                os.makedirs(os.path.dirname(local_file), exist_ok=True)
+                client.download_file(bucket, key, local_file)
+                total += 1
+        logger.info("Downloaded %d files from s3://%s/%s", total, bucket, prefix)
+
+    logger.info("Download complete: s3://%s/%s -> %s", bucket, prefix, local_dir)
+
+
 def download_file_from_s3(
     s3_uri: str,
     region: Optional[str] = None,


### PR DESCRIPTION
  ## Summary

  Enables iterative training by allowing `model.base_model_name` to be an
  `s3://` URI pointing to a previously uploaded fine-tuned checkpoint (e.g.
  the `final/` prefix written by the S3 upload callback).

  - **`utils/s3_utils.py`** — new `download_directory_from_s3()` that
    mirrors the existing upload logic: uses `s5cmd sync` when available
    (~1.25 GiB/s), falls back to boto3 list + download.
  - **`core/config.py`** — adds `s3_region` / `s3_endpoint_url` to
    `ModelConfig`, matching the existing `DatasetInfo` pattern.
  - **`core/trainer_base.py`** — new `_maybe_download_s3_model()` called in
    `__init__` before any trainer setup. Local rank 0 per node downloads to a
    URI-keyed cache dir under `/tmp` and writes a sentinel file; non-zero
    local ranks busy-wait on the sentinel (1-hour timeout). After the method
    returns, `base_model_name` is the local path — all existing trainer
    `setup_model()` implementations work unchanged.
  - **`recipes/training/sft/llama3_3B_s3_model.yaml`** — new recipe template
    demonstrating an S3 model + S3 dataset configuration.
  - **`recipes/training/README.md`** — new *Model Sources* and *S3 Model
    Loading* sections; updated recipe index and Quick Start.