### PR TITLE
fix: DPO training from PEFT checkpoints on MoE models (Qwen3-30B-A3B)

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -303,19 +303,68 @@ class BaseTrainer(ABC):
         
         return tokenizer
 
-    def apply_lora_to_model(self, model, task_type: TaskType = TaskType.CAUSAL_LM, 
-                           quantization_config: Optional[BitsAndBytesConfig] = None):
+    def load_base_model_for_training(self, model_kwargs: Dict[str, Any]):
+        """Load the base model, transparently handling PEFT/LoRA checkpoints.
+
+        When base_model_name is a local directory containing adapter_config.json,
+        loads the original base model from adapter_config.base_model_name_or_path
+        (so the architecture exactly matches the saved adapter weights) and stores
+        the checkpoint path for apply_lora_to_model to resume from.
+
+        When base_model_name is a plain HuggingFace ID or a non-PEFT local dir,
+        behaves identically to AutoModelForCausalLM.from_pretrained.
+        """
+        from peft import PeftConfig
+
+        model_path = self.config.model.base_model_name
+        self._peft_adapter_path = None
+
+        adapter_config_path = os.path.join(model_path, "adapter_config.json")
+        if os.path.isdir(model_path) and os.path.exists(adapter_config_path):
+            peft_cfg = PeftConfig.from_pretrained(model_path)
+            base_model_path = peft_cfg.base_model_name_or_path
+            self.logger.info(
+                "Detected PEFT checkpoint; loading base model from %s", base_model_path
+            )
+            self._peft_adapter_path = model_path
+            # ignore_mismatched_sizes is not needed when loading the base model clean.
+            clean_kwargs = {k: v for k, v in model_kwargs.items() if k != "ignore_mismatched_sizes"}
+            return AutoModelForCausalLM.from_pretrained(base_model_path, **clean_kwargs)
+
+        return AutoModelForCausalLM.from_pretrained(model_path, **model_kwargs)
+
+    def apply_lora_to_model(self, model, task_type: TaskType = TaskType.CAUSAL_LM,
+                            quantization_config: Optional[BitsAndBytesConfig] = None):
         """Apply LoRA/QLoRA to a model.
-        
+
+        When a PEFT checkpoint was detected during load_base_model_for_training,
+        resumes from that adapter instead of creating a new one.
+
         Args:
             model: The model to apply LoRA to.
             task_type: The task type for LoRA (CAUSAL_LM or SEQ_CLS).
             quantization_config: Optional quantization configuration to determine if using QLoRA.
-            
+
         Returns:
             The model with LoRA applied.
         """
         if not getattr(self.config.model, 'use_lora', False):
+            return model
+
+        peft_adapter_path = getattr(self, '_peft_adapter_path', None)
+        if peft_adapter_path is not None:
+            from peft import PeftModel
+            self.logger.info("Loading existing PEFT adapter from %s", peft_adapter_path)
+            model = PeftModel.from_pretrained(model, peft_adapter_path, is_trainable=True)
+            trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+            total_params = sum(p.numel() for p in model.parameters())
+            self.logger.info(
+                "PEFT adapter loaded - Trainable params: %s / %s (%.2f%%)",
+                f"{trainable_params:,}", f"{total_params:,}",
+                100 * trainable_params / total_params,
+            )
+            if trainable_params == 0:
+                raise ValueError("No trainable parameters after loading PEFT adapter.")
             return model
 
         self.logger.info("Applying LoRA configuration...")

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -48,13 +48,43 @@ def _patch_peft_moe_multi_adapter():
         _orig_car = LoraModel._create_and_replace
 
         def _patched_car(self, lora_config, adapter_name, *args, **kwargs):
+            # Fix 1: temporarily hide other adapters' target_parameters to bypass
+            # PEFT 0.19.0's single-target_parameters-per-model restriction.
             saved = {}
             if getattr(lora_config, "target_parameters", None):
                 for k, conf in self.peft_config.items():
                     if k != adapter_name and getattr(conf, "target_parameters", None):
                         saved[k] = conf.target_parameters
                         conf.target_parameters = None
+
             try:
+                # Fix 2: prevent nested ParamWrapper when adding a second MoE adapter.
+                # _inject_parameters walks named_modules, finds an existing ParamWrapper,
+                # and calls _create_and_replace(target=base_layer, parent=ParamWrapper).
+                # Since base_layer is not a LoraLayer the original code creates a new
+                # ParamWrapper nested inside the existing one, breaking TRL's ref-adapter
+                # parameter path lookups (lora_A.ref lives in the inner wrapper instead
+                # of the outer one). Detect this case and call update_layer directly.
+                try:
+                    from peft.tuners.lora.layer import ParamWrapper
+                    parameter_name = kwargs.get("parameter_name", None)
+                    # positional args order: target, target_name, parent, current_key
+                    if len(args) >= 3 and parameter_name is not None:
+                        parent = args[2]
+                        current_key = args[3] if len(args) >= 4 else kwargs.get("current_key", "")
+                        if (isinstance(parent, ParamWrapper)
+                                and parameter_name == getattr(parent, "parameter_name", None)
+                                and adapter_name not in parent.lora_A):
+                            from peft.utils.other import get_pattern_key
+                            r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
+                            alpha_key = get_pattern_key(lora_config.alpha_pattern.keys(), current_key)
+                            r = lora_config.rank_pattern.get(r_key, lora_config.r)
+                            alpha = lora_config.alpha_pattern.get(alpha_key, lora_config.lora_alpha)
+                            parent.update_layer(adapter_name, r, lora_alpha=alpha, config=lora_config)
+                            return
+                except (ImportError, AttributeError):
+                    pass
+
                 return _orig_car(self, lora_config, adapter_name, *args, **kwargs)
             finally:
                 for k, v in saved.items():

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -95,10 +95,20 @@ def _patch_peft_moe_multi_adapter():
                         continue
                     if not any(param_name == t or module_path.endswith(f".{t}") for t in target_params):
                         continue
-                    r_key = get_pattern_key(peft_cfg.rank_pattern.keys(), module_path)
-                    alpha_key = get_pattern_key(peft_cfg.alpha_pattern.keys(), module_path)
-                    r = peft_cfg.rank_pattern.get(r_key, peft_cfg.r)
-                    alpha = peft_cfg.alpha_pattern.get(alpha_key, peft_cfg.lora_alpha)
+                    # Infer r from existing adapter weights rather than from peft_cfg.r,
+                    # because the checkpoint may have been trained with a different r than
+                    # what the current recipe specifies. For 3D MoE parameters,
+                    # lora_A.weight.shape[0] == r * num_experts, so we back-calculate r.
+                    existing = [k for k in module.lora_A if k != adapter_name]
+                    if existing:
+                        r_times_n = module.lora_A[existing[0]].weight.shape[0]
+                        r = r_times_n // max(1, module.num_experts)
+                        alpha = module.lora_alpha.get(existing[0], r)
+                    else:
+                        r_key = get_pattern_key(peft_cfg.rank_pattern.keys(), module_path)
+                        alpha_key = get_pattern_key(peft_cfg.alpha_pattern.keys(), module_path)
+                        r = peft_cfg.rank_pattern.get(r_key, peft_cfg.r)
+                        alpha = peft_cfg.alpha_pattern.get(alpha_key, peft_cfg.lora_alpha)
                     module.update_layer(adapter_name, r, lora_alpha=alpha, config=peft_cfg)
                     if not is_active:
                         module.lora_A[adapter_name].requires_grad_(False)

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -33,64 +33,80 @@ def _patch_weight_converter_init():
 _patch_weight_converter_init()
 
 
-# Workaround for PEFT 0.19.0 adding a restriction that only one LoRA adapter
-# per model can use target_parameters (the MoE-specific fused-layer mechanism).
-# TRL 1.2+ needs two adapters ("default" + "ref") for DPO reference logprob
-# computation. The restriction was not present in PEFT <= 0.17.0 and is
-# overly conservative — the underlying MoE layer code handles multiple adapters
-# correctly. We bypass it by temporarily hiding other adapters' target_parameters
-# while the new adapter's layers are being registered.
+# Workaround for two bugs in PEFT 0.19.0 when using TRL 1.2+ DPO with MoE LoRA:
+#
+# Fix 1 — single-adapter restriction: PEFT 0.19.0 raises ValueError if any two
+# LoRA adapters on the same model both use target_parameters. TRL 1.2 adds a
+# second adapter ("ref") for reference logprob computation, triggering this
+# check. We bypass it by temporarily hiding other adapters' target_parameters
+# during _create_and_replace (which is called for every regular LoRA layer).
+#
+# Fix 2 — silent skip of existing ParamWrapper: _inject_parameters iterates
+# named_modules to find parameters to wrap. After the first adapter creates
+# ParamWrapper at "...experts.0.gate_up_proj", the second adapter's iteration
+# finds ParamWrapper and calls named_parameters(recurse=False) on it, yielding
+# ("base_layer", param). The key built is "...experts.0.gate_up_proj.base_layer",
+# which doesn't match target_names={"gate_up_proj"} via endswith, so the second
+# adapter is silently never injected into any MoE layer. We post-process
+# inject_adapter to find ParamWrapper modules that are still missing the new
+# adapter and call update_layer directly.
 def _patch_peft_moe_multi_adapter():
     try:
         from peft.tuners.lora.model import LoraModel
         if getattr(LoraModel, "_fai_rl_multi_adapter_patched", False):
             return
+
         _orig_car = LoraModel._create_and_replace
 
         def _patched_car(self, lora_config, adapter_name, *args, **kwargs):
-            # Fix 1: temporarily hide other adapters' target_parameters to bypass
-            # PEFT 0.19.0's single-target_parameters-per-model restriction.
             saved = {}
             if getattr(lora_config, "target_parameters", None):
                 for k, conf in self.peft_config.items():
                     if k != adapter_name and getattr(conf, "target_parameters", None):
                         saved[k] = conf.target_parameters
                         conf.target_parameters = None
-
             try:
-                # Fix 2: prevent nested ParamWrapper when adding a second MoE adapter.
-                # _inject_parameters walks named_modules, finds an existing ParamWrapper,
-                # and calls _create_and_replace(target=base_layer, parent=ParamWrapper).
-                # Since base_layer is not a LoraLayer the original code creates a new
-                # ParamWrapper nested inside the existing one, breaking TRL's ref-adapter
-                # parameter path lookups (lora_A.ref lives in the inner wrapper instead
-                # of the outer one). Detect this case and call update_layer directly.
-                try:
-                    from peft.tuners.lora.layer import ParamWrapper
-                    parameter_name = kwargs.get("parameter_name", None)
-                    # positional args order: target, target_name, parent, current_key
-                    if len(args) >= 3 and parameter_name is not None:
-                        parent = args[2]
-                        current_key = args[3] if len(args) >= 4 else kwargs.get("current_key", "")
-                        if (isinstance(parent, ParamWrapper)
-                                and parameter_name == getattr(parent, "parameter_name", None)
-                                and adapter_name not in parent.lora_A):
-                            from peft.utils.other import get_pattern_key
-                            r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
-                            alpha_key = get_pattern_key(lora_config.alpha_pattern.keys(), current_key)
-                            r = lora_config.rank_pattern.get(r_key, lora_config.r)
-                            alpha = lora_config.alpha_pattern.get(alpha_key, lora_config.lora_alpha)
-                            parent.update_layer(adapter_name, r, lora_alpha=alpha, config=lora_config)
-                            return
-                except (ImportError, AttributeError):
-                    pass
-
                 return _orig_car(self, lora_config, adapter_name, *args, **kwargs)
             finally:
                 for k, v in saved.items():
                     self.peft_config[k].target_parameters = v
 
         LoraModel._create_and_replace = _patched_car
+
+        _orig_inject = LoraModel.inject_adapter
+
+        def _patched_inject(self, model, adapter_name, *args, **kwargs):
+            _orig_inject(self, model, adapter_name, *args, **kwargs)
+            try:
+                from peft.tuners.lora.layer import ParamWrapper
+                from peft.utils.other import get_pattern_key
+                peft_cfg = self.peft_config.get(adapter_name)
+                if peft_cfg is None or not getattr(peft_cfg, "target_parameters", None):
+                    return
+                target_params = set(peft_cfg.target_parameters)
+                is_active = adapter_name in (getattr(self, "active_adapters", None) or [])
+                for module_path, module in model.named_modules():
+                    if not isinstance(module, ParamWrapper):
+                        continue
+                    if adapter_name in module.lora_A:
+                        continue
+                    param_name = getattr(module, "parameter_name", None)
+                    if param_name is None:
+                        continue
+                    if not any(param_name == t or module_path.endswith(f".{t}") for t in target_params):
+                        continue
+                    r_key = get_pattern_key(peft_cfg.rank_pattern.keys(), module_path)
+                    alpha_key = get_pattern_key(peft_cfg.alpha_pattern.keys(), module_path)
+                    r = peft_cfg.rank_pattern.get(r_key, peft_cfg.r)
+                    alpha = peft_cfg.alpha_pattern.get(alpha_key, peft_cfg.lora_alpha)
+                    module.update_layer(adapter_name, r, lora_alpha=alpha, config=peft_cfg)
+                    if not is_active:
+                        module.lora_A[adapter_name].requires_grad_(False)
+                        module.lora_B[adapter_name].requires_grad_(False)
+            except (ImportError, AttributeError):
+                pass
+
+        LoraModel.inject_adapter = _patched_inject
         LoraModel._fai_rl_multi_adapter_patched = True
     except (ImportError, AttributeError):
         pass

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -32,6 +32,41 @@ def _patch_weight_converter_init():
 
 _patch_weight_converter_init()
 
+
+# Workaround for PEFT 0.19.0 adding a restriction that only one LoRA adapter
+# per model can use target_parameters (the MoE-specific fused-layer mechanism).
+# TRL 1.2+ needs two adapters ("default" + "ref") for DPO reference logprob
+# computation. The restriction was not present in PEFT <= 0.17.0 and is
+# overly conservative — the underlying MoE layer code handles multiple adapters
+# correctly. We bypass it by temporarily hiding other adapters' target_parameters
+# while the new adapter's layers are being registered.
+def _patch_peft_moe_multi_adapter():
+    try:
+        from peft.tuners.lora.model import LoraModel
+        if getattr(LoraModel, "_fai_rl_multi_adapter_patched", False):
+            return
+        _orig_car = LoraModel._create_and_replace
+
+        def _patched_car(self, lora_config, adapter_name, *args, **kwargs):
+            saved = {}
+            if getattr(lora_config, "target_parameters", None):
+                for k, conf in self.peft_config.items():
+                    if k != adapter_name and getattr(conf, "target_parameters", None):
+                        saved[k] = conf.target_parameters
+                        conf.target_parameters = None
+            try:
+                return _orig_car(self, lora_config, adapter_name, *args, **kwargs)
+            finally:
+                for k, v in saved.items():
+                    self.peft_config[k].target_parameters = v
+
+        LoraModel._create_and_replace = _patched_car
+        LoraModel._fai_rl_multi_adapter_patched = True
+    except (ImportError, AttributeError):
+        pass
+
+_patch_peft_moe_multi_adapter()
+
 if TYPE_CHECKING:
     from transformers import BitsAndBytesConfig
 import wandb

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from transformers import BitsAndBytesConfig
 import wandb
 import torch
-from transformers import AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import LoraConfig, get_peft_model, TaskType, prepare_model_for_kbit_training
 
 from .config import ExperimentConfig

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -5,6 +5,33 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, TYPE_CHECKING
 
+# Workaround for a bug in transformers where build_peft_weight_mapping passes
+# distributed_operation/quantization_operation as constructor kwargs to
+# WeightConverter, but WeightConverter.__init__ only accepts source_patterns,
+# target_patterns, and operations. This is triggered when loading a PEFT
+# checkpoint for a MoE model (e.g. Qwen3-30B-A3B).
+def _patch_weight_converter_init():
+    try:
+        from transformers.core_model_loading import WeightConverter
+        if getattr(WeightConverter, "_fai_rl_patched", False):
+            return
+        _orig_init = WeightConverter.__init__
+
+        def _patched_init(self, source_patterns, target_patterns, operations, **kwargs):
+            _orig_init(self, source_patterns, target_patterns, operations)
+            for k, v in kwargs.items():
+                try:
+                    setattr(self, k, v)
+                except (AttributeError, TypeError):
+                    pass
+
+        WeightConverter.__init__ = _patched_init
+        WeightConverter._fai_rl_patched = True
+    except (ImportError, AttributeError):
+        pass
+
+_patch_weight_converter_init()
+
 if TYPE_CHECKING:
     from transformers import BitsAndBytesConfig
 import wandb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.27"
+version = "0.1.28"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/trainers/cpt_trainer.py
+++ b/trainers/cpt_trainer.py
@@ -34,10 +34,7 @@ class CPTTrainer(BaseTrainer):
         quantization_config = self.create_quantization_config()
         model_kwargs = self.prepare_model_kwargs(quantization_config)
 
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.config.model.base_model_name,
-            **model_kwargs
-        )
+        self.model = self.load_base_model_for_training(model_kwargs)
 
         self.tokenizer = self.setup_tokenizer_with_model(self.model)
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)

--- a/trainers/dpo_trainer.py
+++ b/trainers/dpo_trainer.py
@@ -150,19 +150,6 @@ class DPOTrainer(BaseTrainer):
         
         self.logger.info(f"Total dataset loaded with {total_examples} valid examples from {len(datasets)} datasets")
 
-    def _has_moe_target_parameters(self) -> bool:
-        """Return True if the loaded PEFT model uses MoE-specific target_parameters.
-
-        PEFT uses target_parameters (rather than target_modules) for fused MoE
-        layers such as gate_up_proj / down_proj on Qwen3-MoE. TRL 1.2+ creates
-        a second "ref" PEFT adapter which PEFT forbids when target_parameters is
-        already in use, so we need to detect this and take an alternate path.
-        """
-        for adapter_cfg in getattr(self.model, "peft_config", {}).values():
-            if getattr(adapter_cfg, "target_parameters", None):
-                return True
-        return False
-
     def setup_training_args(self) -> DPOConfig:
         """Create DPO training configuration."""
         # Set report_to based on wandb configuration to prevent automatic wandb initialization
@@ -173,21 +160,6 @@ class DPOTrainer(BaseTrainer):
         gradient_checkpointing_kwargs = None
         if self.config.training.gradient_checkpointing:
             gradient_checkpointing_kwargs = {"use_reentrant": False}
-
-        # TRL 1.2+ adds a second "ref" PEFT adapter as its implicit reference model.
-        # PEFT forbids this when the existing adapter uses target_parameters (MoE models
-        # such as Qwen3-30B-A3B). precompute_ref_log_probs=True makes TRL disable adapters
-        # temporarily instead of creating a second one, bypassing the constraint.
-        precompute_ref_log_probs = (
-            getattr(self.config.model, "use_lora", False)
-            and self.model is not None
-            and self._has_moe_target_parameters()
-        )
-        if precompute_ref_log_probs:
-            self.logger.info(
-                "MoE model with target_parameters detected: setting precompute_ref_log_probs=True "
-                "to avoid PEFT's single-adapter-with-target_parameters constraint."
-            )
 
         return DPOConfig(
             output_dir=self.config.training.output_dir,
@@ -214,7 +186,6 @@ class DPOTrainer(BaseTrainer):
             prediction_loss_only=self.config.training.prediction_loss_only,
             report_to=report_to,
             ddp_find_unused_parameters=self.config.training.ddp_find_unused_parameters,
-            precompute_ref_log_probs=precompute_ref_log_probs,
         )
 
     def setup_trainer(self):

--- a/trainers/dpo_trainer.py
+++ b/trainers/dpo_trainer.py
@@ -150,17 +150,45 @@ class DPOTrainer(BaseTrainer):
         
         self.logger.info(f"Total dataset loaded with {total_examples} valid examples from {len(datasets)} datasets")
 
+    def _has_moe_target_parameters(self) -> bool:
+        """Return True if the loaded PEFT model uses MoE-specific target_parameters.
+
+        PEFT uses target_parameters (rather than target_modules) for fused MoE
+        layers such as gate_up_proj / down_proj on Qwen3-MoE. TRL 1.2+ creates
+        a second "ref" PEFT adapter which PEFT forbids when target_parameters is
+        already in use, so we need to detect this and take an alternate path.
+        """
+        for adapter_cfg in getattr(self.model, "peft_config", {}).values():
+            if getattr(adapter_cfg, "target_parameters", None):
+                return True
+        return False
+
     def setup_training_args(self) -> DPOConfig:
         """Create DPO training configuration."""
         # Set report_to based on wandb configuration to prevent automatic wandb initialization
         report_to = ["wandb"] if self.config.wandb.enabled else []
-        
+
         # Set gradient checkpointing kwargs to use non-reentrant mode for DDP compatibility
         # This fixes the "Expected to mark a variable ready only once" error with LoRA + DDP
         gradient_checkpointing_kwargs = None
         if self.config.training.gradient_checkpointing:
             gradient_checkpointing_kwargs = {"use_reentrant": False}
-        
+
+        # TRL 1.2+ adds a second "ref" PEFT adapter as its implicit reference model.
+        # PEFT forbids this when the existing adapter uses target_parameters (MoE models
+        # such as Qwen3-30B-A3B). precompute_ref_log_probs=True makes TRL disable adapters
+        # temporarily instead of creating a second one, bypassing the constraint.
+        precompute_ref_log_probs = (
+            getattr(self.config.model, "use_lora", False)
+            and self.model is not None
+            and self._has_moe_target_parameters()
+        )
+        if precompute_ref_log_probs:
+            self.logger.info(
+                "MoE model with target_parameters detected: setting precompute_ref_log_probs=True "
+                "to avoid PEFT's single-adapter-with-target_parameters constraint."
+            )
+
         return DPOConfig(
             output_dir=self.config.training.output_dir,
             per_device_train_batch_size=self.config.training.per_device_train_batch_size,
@@ -186,6 +214,7 @@ class DPOTrainer(BaseTrainer):
             prediction_loss_only=self.config.training.prediction_loss_only,
             report_to=report_to,
             ddp_find_unused_parameters=self.config.training.ddp_find_unused_parameters,
+            precompute_ref_log_probs=precompute_ref_log_probs,
         )
 
     def setup_trainer(self):

--- a/trainers/dpo_trainer.py
+++ b/trainers/dpo_trainer.py
@@ -38,10 +38,7 @@ class DPOTrainer(BaseTrainer):
         model_kwargs = self.prepare_model_kwargs(quantization_config)
 
         # Load main model
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.config.model.base_model_name,
-            **model_kwargs
-        )
+        self.model = self.load_base_model_for_training(model_kwargs)
 
         # When using LoRA, skip loading a separate reference model.
         # TRL's DPOTrainer supports ref_model=None with LoRA — it computes

--- a/trainers/grpo_trainer.py
+++ b/trainers/grpo_trainer.py
@@ -41,10 +41,7 @@ class GRPOTrainer(BaseTrainer):
         model_kwargs = self.prepare_model_kwargs(quantization_config)
 
         # Load main model
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.config.model.base_model_name,
-            **model_kwargs
-        )
+        self.model = self.load_base_model_for_training(model_kwargs)
 
         # Setup tokenizer and resize embeddings using base class method
         self.tokenizer = self.setup_tokenizer_with_model(self.model)

--- a/trainers/sft_trainer.py
+++ b/trainers/sft_trainer.py
@@ -37,10 +37,7 @@ class SFTTrainer(BaseTrainer):
         model_kwargs = self.prepare_model_kwargs(quantization_config)
         
         # Load main model
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.config.model.base_model_name,
-            **model_kwargs
-        )
+        self.model = self.load_base_model_for_training(model_kwargs)
 
         # Setup tokenizer and resize embeddings using base class method
         self.tokenizer = self.setup_tokenizer_with_model(self.model)


### PR DESCRIPTION
  ## Summary

  - Adds `load_base_model_for_training()` to `BaseTrainer` so all trainers
    (SFT, DPO, CPT, GRPO) transparently detect and resume from PEFT/LoRA
    checkpoints — loading the original base model first, then applying the
    saved adapter — rather than passing the checkpoint path directly to
    `AutoModelForCausalLM.from_pretrained`.

  - Applies three monkey-patches at import time in `trainer_base.py` to work
    around incompatibilities between **transformers 5.8**, **PEFT 0.19.0**, and
    **TRL 1.2** when running DPO on a MoE model with LoRA:

    1. **`WeightConverter.__init__` kwargs** — `transformers.build_peft_weight_mapping`
       passes `distributed_operation` / `quantization_operation` kwargs that
       `WeightConverter` does not accept, crashing on MoE checkpoint load.

    2. **PEFT single-adapter restriction** — PEFT 0.19.0 raises `ValueError` if
       two LoRA adapters both use `target_parameters` (the MoE fused-layer
       mechanism). TRL 1.2 adds a second `"ref"` adapter for DPO reference
       logprob computation, triggering this check. The patch temporarily hides
       other adapters' `target_parameters` during `_create_and_replace`.

    3. **Silent skip of MoE layers for second adapter** — `_inject_parameters`
       iterates `named_modules` and builds the key `"...gate_up_proj.base_layer"`
       for an existing `ParamWrapper`, which never matches `target_names=
       {"gate_up_proj"}`. The `"ref"` adapter is injected into all regular LoRA
       layers but silently skipped for every MoE `ParamWrapper`, causing TRL's
       `ref_param.data.copy_(param.data)` to either raise `AttributeError` or a
       shape mismatch. The patch post-processes `inject_adapter` to find
       `ParamWrapper` modules still missing the new adapter and calls
       `update_layer` directly, inferring `r` from the existing adapter's weight
       shape (not the recipe config) to handle checkpoints trained with a
       different rank.