### PR TITLE
Fix: replace unsafe eval in multiple-choice prompt formatting

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -39,6 +39,7 @@ from core.config import ExperimentConfig
 from utils.config_validation import validate_api_config
 from utils.recipe_overrides import apply_overrides_to_recipe, load_recipe_from_yaml
 from utils.logging_utils import setup_logging, SafeLogger
+from utils.dataset_utils import format_multiple_choice_for_inference
 from utils.device_utils import (
     get_device_type,
     get_optimal_dtype,
@@ -49,44 +50,6 @@ from utils.device_utils import (
 # This prevents logging errors from crashing long-running inference jobs
 _base_logger = setup_logging("Inference")
 logger = SafeLogger(_base_logger)
-
-
-def format_multiple_choice_for_inference(choices, choice_labels=None):
-    """
-    Format a list of choices into A/B/C/D format for inference.
-    
-    Args:
-        choices: List of choice strings or string representation of list
-        choice_labels: List of labels to use (default: ["A", "B", "C", "D", ...])
-    
-    Returns:
-        Formatted string with labeled choices
-    """
-    if choice_labels is None:
-        choice_labels = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
-    
-    # Handle string representation of list
-    if isinstance(choices, str):
-        try:
-            # Try to evaluate as list if it looks like one
-            if choices.startswith('[') and choices.endswith(']'):
-                choices = eval(choices)
-            else:
-                # Split by comma if it's comma-separated
-                choices = [choice.strip() for choice in choices.split(',')]
-        except:
-            # If parsing fails, treat as single choice
-            choices = [choices]
-    
-    formatted_choices = []
-    for i, choice in enumerate(choices):
-        if i < len(choice_labels):
-            formatted_choices.append(f"{choice_labels[i]}. {choice}")
-        else:
-            # Fallback if we have more choices than labels
-            formatted_choices.append(f"{i+1}. {choice}")
-    
-    return "\n".join(formatted_choices)
 
 
 def has_template_placeholders(template):

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_dataset_utils():
+    module_path = Path(__file__).resolve().parents[1] / "utils" / "dataset_utils.py"
+    spec = importlib.util.spec_from_file_location("dataset_utils", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dataset_utils = _load_dataset_utils()
+
+
+def test_format_multiple_choice_parses_stringified_list():
+    choices = "['red', 'green', 'blue']"
+
+    assert dataset_utils.format_multiple_choice_for_inference(choices) == (
+        "A. red\nB. green\nC. blue"
+    )
+
+
+def test_format_multiple_choice_does_not_execute_stringified_input(tmp_path):
+    marker = tmp_path / "executed"
+    choices = f"[__import__('pathlib').Path(r'{marker}').touch()]"
+
+    formatted = dataset_utils.format_multiple_choice_for_inference(choices)
+
+    assert formatted == f"A. {choices}"
+    assert not marker.exists()
+
+
+def test_format_multiple_choice_splits_comma_separated_string():
+    assert dataset_utils.format_multiple_choice_for_inference("red, green, blue") == (
+        "A. red\nB. green\nC. blue"
+    )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,7 @@ from .logging_utils import (
 from .config_validation import validate_api_endpoint, validate_api_key, validate_api_config
 from .api_utils import generate_response_by_api
 from .dataset_utils import (
+    format_multiple_choice_for_inference,
     is_math_dataset,
     get_template_for_dataset,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "validate_api_key",
     "validate_api_config",
     "generate_response_by_api",
+    "format_multiple_choice_for_inference",
     "is_math_dataset",
     "get_template_for_dataset",
     # Device utilities

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,7 +1,8 @@
 """Dataset utilities for handling different dataset types and templates."""
 
+import ast
 import os
-from typing import Type, Any
+from typing import Any, Iterable, Optional, Sequence
 
 
 _LOCAL_FILE_FORMATS = {
@@ -10,6 +11,48 @@ _LOCAL_FILE_FORMATS = {
     ".csv": "csv",
     ".parquet": "parquet",
 }
+
+DEFAULT_CHOICE_LABELS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+
+def _coerce_choices(choices: Any) -> Iterable[Any]:
+    """Normalize choice values from datasets without executing arbitrary code."""
+    if not isinstance(choices, str):
+        return choices
+
+    stripped = choices.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = ast.literal_eval(stripped)
+        except (ValueError, SyntaxError):
+            return [choices]
+        if isinstance(parsed, (list, tuple)):
+            return parsed
+        return [choices]
+
+    return [choice.strip() for choice in choices.split(",")]
+
+
+def format_multiple_choice_for_inference(
+    choices: Any,
+    choice_labels: Optional[Sequence[str]] = None,
+) -> str:
+    """
+    Format choices into A/B/C/D-style lines for inference prompts.
+
+    Stringified Python lists are parsed with ast.literal_eval rather than eval
+    so dataset values cannot execute code during prompt formatting.
+    """
+    labels = choice_labels or DEFAULT_CHOICE_LABELS
+
+    formatted_choices = []
+    for i, choice in enumerate(_coerce_choices(choices)):
+        if i < len(labels):
+            formatted_choices.append(f"{labels[i]}. {choice}")
+        else:
+            formatted_choices.append(f"{i + 1}. {choice}")
+
+    return "\n".join(formatted_choices)
 
 
 def _load_from_s3(s3_uri: str, dataset_info):


### PR DESCRIPTION
## Summary

Fixes unsafe parsing in multiple-choice inference prompt formatting by replacing `eval()` with `ast.literal_eval()`.

## What Changed

- Moved `format_multiple_choice_for_inference` into `utils/dataset_utils.py`
- Reused the shared helper from `inference/inference.py`
- Exported the helper from `utils/__init__.py`
- Added regression tests for:
  - stringified choice lists
  - comma-separated choices
  - executable-looking input that must not run

## Why

The previous inference formatter used `eval()` when a dataset `choices` value looked like a Python list. That could execute arbitrary code from malformed or malicious dataset content during prompt formatting.

Using `ast.literal_eval()` preserves support for stringified list values while only allowing safe Python literals.

## Validation

- `python -m compileall -q .`
- `git diff --check`
- Direct regression harness for `tests/test_dataset_utils.py`

(Full `pytest` was not run because `pytest` is not installed in the local environment.)