### PR TITLE
fix(trainers): resolve DeepSpeed 'auto' batch fields before ZeRO-3 zero.Init

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -564,11 +564,44 @@ class BaseTrainer(ABC):
             return
         # Retain on self: transformers holds only a weakref to this object, and it
         # is what makes from_pretrained() partition parameters per rank.
-        self._hf_deepspeed_config = HfDeepSpeedConfig(ds_config)
+        self._hf_deepspeed_config = HfDeepSpeedConfig(self._resolve_ds_auto_batch(ds_config))
         self.logger.info(
             "Registered ZeRO-3 HfDeepSpeedConfig before model load; "
             "parameters will be partitioned across ranks at from_pretrained time."
         )
+
+    def _resolve_ds_auto_batch(self, ds_config: Any) -> Dict[str, Any]:
+        """Return the DeepSpeed config as a dict with 'auto' batch fields resolved.
+
+        ``deepspeed.zero.Init`` (invoked inside ``from_pretrained`` once ZeRO-3 is
+        active) builds a full ``DeepSpeedConfig`` and asserts ``train_batch_size >
+        0``. The shipped config leaves the batch fields as the string ``"auto"`` for
+        HF's Trainer to fill in later -- but that resolution happens when
+        ``TrainingArguments`` is built, which is *after* the model loads. So at
+        load time DeepSpeed compares the literal ``"auto"`` against ``0`` and raises
+        ``TypeError: '>' not supported between instances of 'str' and 'int'``.
+
+        We substitute concrete values from the recipe and ``WORLD_SIZE`` here, only
+        for the early registration. The HF Trainer later builds its own config from
+        the original ``deepspeed_config`` path and resolves ``"auto"`` as usual, so
+        this patched copy doesn't affect anything downstream.
+        """
+        import json
+        import copy
+
+        cfg = ds_config
+        if isinstance(cfg, str):
+            with open(cfg) as f:
+                cfg = json.load(f)
+        cfg = copy.deepcopy(cfg)
+
+        world_size = int(os.environ.get("WORLD_SIZE", 1) or 1)
+        micro = self.config.training.per_device_train_batch_size
+        accum = self.config.training.gradient_accumulation_steps
+        cfg["train_micro_batch_size_per_gpu"] = micro
+        cfg["gradient_accumulation_steps"] = accum
+        cfg["train_batch_size"] = micro * accum * world_size
+        return cfg
 
     def load_base_model_for_training(self, model_kwargs: Dict[str, Any]):
         """Load the base model, transparently handling PEFT/LoRA checkpoints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.32"
+version = "0.1.33"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_deepspeed_zero3_init.py
+++ b/tests/test_deepspeed_zero3_init.py
@@ -8,8 +8,21 @@ logic that gates it: ``BaseTrainer._deepspeed_zero_stage``.
 """
 
 import json
+from types import SimpleNamespace
 
 from core.trainer_base import BaseTrainer
+
+
+def _fake_trainer(micro, accum):
+    """Minimal stand-in carrying just the recipe fields _resolve_ds_auto_batch reads."""
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            training=SimpleNamespace(
+                per_device_train_batch_size=micro,
+                gradient_accumulation_steps=accum,
+            )
+        )
+    )
 
 
 def test_stage_from_zero3_path(tmp_path):
@@ -54,3 +67,44 @@ def test_real_repo_zero3_config_is_stage_3():
     repo_root = Path(__file__).resolve().parents[1]
     cfg = repo_root / "configs" / "deepspeed" / "zero3_config.json"
     assert BaseTrainer._deepspeed_zero_stage(str(cfg)) == 3
+
+
+def test_resolve_auto_batch_from_dict(monkeypatch):
+    """'auto' batch fields are replaced with ints DeepSpeed's zero.Init can parse."""
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    trainer = _fake_trainer(micro=1, accum=8)
+    cfg = BaseTrainer._resolve_ds_auto_batch(
+        trainer,
+        {
+            "train_batch_size": "auto",
+            "train_micro_batch_size_per_gpu": "auto",
+            "gradient_accumulation_steps": "auto",
+        },
+    )
+    assert cfg["train_micro_batch_size_per_gpu"] == 1
+    assert cfg["gradient_accumulation_steps"] == 8
+    # train_batch_size = micro * accum * world_size = 1 * 8 * 2
+    assert cfg["train_batch_size"] == 16
+    # The exact comparison deepspeed._batch_assertion makes must now succeed.
+    assert cfg["train_batch_size"] > 0
+
+
+def test_resolve_auto_batch_defaults_world_size_to_one(monkeypatch):
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    trainer = _fake_trainer(micro=2, accum=4)
+    cfg = BaseTrainer._resolve_ds_auto_batch(trainer, {"train_batch_size": "auto"})
+    assert cfg["train_batch_size"] == 8  # 2 * 4 * 1
+
+
+def test_resolve_auto_batch_reads_path_and_does_not_mutate_input(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    src = {"zero_optimization": {"stage": 3}, "train_batch_size": "auto"}
+    cfg_path = tmp_path / "zero3.json"
+    cfg_path.write_text(json.dumps(src))
+    trainer = _fake_trainer(micro=1, accum=8)
+
+    cfg = BaseTrainer._resolve_ds_auto_batch(trainer, str(cfg_path))
+    assert cfg["train_batch_size"] == 32  # 1 * 8 * 4
+    assert cfg["zero_optimization"]["stage"] == 3
+    # The original file on disk is untouched.
+    assert json.loads(cfg_path.read_text())["train_batch_size"] == "auto"


### PR DESCRIPTION
The ZeRO-3 early-init path registered a plain HfDeepSpeedConfig from the shipped config, whose batch fields are "auto". Unlike HfTrainerDeepSpeedConfig (built later from TrainingArguments), the plain class does not resolve "auto", so deepspeed.zero.Init -- invoked inside from_pretrained -- compared the literal string "auto" against 0 in its train_batch_size assertion and raised "TypeError: '>' not supported between instances of 'str' and 'int'", failing every non-quantized ZeRO-3 load before training started.

Substitute concrete values (per_device_train_batch_size, gradient_accumulation_steps, and micro*accum*WORLD_SIZE) into a copy of the config used only for the early registration. The HF Trainer still reads the original path later and resolves "auto" as usual, so nothing downstream changes and the on-disk config stays generic.