### PR TITLE
Added the version to the log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.33"
+version = "0.1.34"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -5,6 +5,23 @@ from datetime import datetime
 from pathlib import Path
 
 
+def get_package_version() -> str:
+    """Return the installed FAI-RL package version.
+
+    Reads the version from the installed distribution metadata, which reflects
+    the actual wheel that was installed (the real source of truth for "which
+    build is running") rather than any hardcoded module constant. Falls back to
+    "unknown" if the package isn't installed as a distribution (e.g. running
+    from a source checkout that was never `pip install`-ed).
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("FAI-RL")
+    except Exception:
+        return "unknown"
+
+
 def _current_rank() -> int:
     """Best-effort global rank lookup. Reads env vars lazily so this works
     regardless of when the logger is configured relative to dist init.
@@ -286,6 +303,7 @@ class TrainingLogger:
         """Log experiment configuration at start."""
         self.logger.info("="*50)
         self.logger.info("EXPERIMENT START")
+        self.logger.info(f"FAI-RL version: {get_package_version()}")
         self.logger.info("="*50)
 
         for section, values in config.items():


### PR DESCRIPTION
## Added the version to the log.
  In utils/logging_utils.py:
  - New get_package_version() helper that reads the installed distribution version via importlib.metadata.version("FAI-RL"), falling back to "unknown".
  - log_experiment_start() now logs FAI-RL version: <x> right under EXPERIMENT START.