### PR TITLE
fix(trainers): let DeepSpeed derive train_batch_size for ZeRO-3 zero.Init

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -574,17 +574,26 @@ class BaseTrainer(ABC):
         """Return the DeepSpeed config as a dict with 'auto' batch fields resolved.
 
         ``deepspeed.zero.Init`` (invoked inside ``from_pretrained`` once ZeRO-3 is
-        active) builds a full ``DeepSpeedConfig`` and asserts ``train_batch_size >
-        0``. The shipped config leaves the batch fields as the string ``"auto"`` for
-        HF's Trainer to fill in later -- but that resolution happens when
-        ``TrainingArguments`` is built, which is *after* the model loads. So at
-        load time DeepSpeed compares the literal ``"auto"`` against ``0`` and raises
+        active) builds a full ``DeepSpeedConfig`` and asserts both ``train_batch_size
+        > 0`` and ``train_batch_size == micro_batch * grad_acc * world_size``. The
+        shipped config leaves the batch fields as the string ``"auto"`` for HF's
+        Trainer to fill in later -- but that resolution happens when
+        ``TrainingArguments`` is built, which is *after* the model loads. So at load
+        time DeepSpeed compares the literal ``"auto"`` against ``0`` and raises
         ``TypeError: '>' not supported between instances of 'str' and 'int'``.
 
-        We substitute concrete values from the recipe and ``WORLD_SIZE`` here, only
-        for the early registration. The HF Trainer later builds its own config from
-        the original ``deepspeed_config`` path and resolves ``"auto"`` as usual, so
-        this patched copy doesn't affect anything downstream.
+        We substitute concrete micro-batch / grad-accum values from the recipe here,
+        only for the early registration, and deliberately leave ``train_batch_size``
+        unset (``None``) so DeepSpeed *derives* it as ``micro * grad_acc *
+        world_size`` using whatever world size it sees at that moment. We must not
+        compute ``train_batch_size`` ourselves: at ``zero.Init`` time DeepSpeed's
+        comm backend isn't initialized, so it reads ``world_size == 1`` regardless of
+        the real ``WORLD_SIZE`` env -- pinning the product to a multi-GPU value here
+        trips the equality assertion (e.g. ``16 != 1 * 8 * 1``). Letting DeepSpeed
+        fill it in keeps the config internally consistent in every context. The HF
+        Trainer later builds its own config from the original ``deepspeed_config``
+        path and resolves ``"auto"`` as usual, so this copy doesn't affect anything
+        downstream.
         """
         import json
         import copy
@@ -595,12 +604,12 @@ class BaseTrainer(ABC):
                 cfg = json.load(f)
         cfg = copy.deepcopy(cfg)
 
-        world_size = int(os.environ.get("WORLD_SIZE", 1) or 1)
         micro = self.config.training.per_device_train_batch_size
         accum = self.config.training.gradient_accumulation_steps
         cfg["train_micro_batch_size_per_gpu"] = micro
         cfg["gradient_accumulation_steps"] = accum
-        cfg["train_batch_size"] = micro * accum * world_size
+        # Let DeepSpeed derive train_batch_size from its own world size; see docstring.
+        cfg["train_batch_size"] = None
         return cfg
 
     def load_base_model_for_training(self, model_kwargs: Dict[str, Any]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.33"
+version = "0.1.34"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_deepspeed_zero3_init.py
+++ b/tests/test_deepspeed_zero3_init.py
@@ -70,7 +70,7 @@ def test_real_repo_zero3_config_is_stage_3():
 
 
 def test_resolve_auto_batch_from_dict(monkeypatch):
-    """'auto' batch fields are replaced with ints DeepSpeed's zero.Init can parse."""
+    """'auto' micro/accum become ints; train_batch_size is left for DeepSpeed."""
     monkeypatch.setenv("WORLD_SIZE", "2")
     trainer = _fake_trainer(micro=1, accum=8)
     cfg = BaseTrainer._resolve_ds_auto_batch(
@@ -83,17 +83,19 @@ def test_resolve_auto_batch_from_dict(monkeypatch):
     )
     assert cfg["train_micro_batch_size_per_gpu"] == 1
     assert cfg["gradient_accumulation_steps"] == 8
-    # train_batch_size = micro * accum * world_size = 1 * 8 * 2
-    assert cfg["train_batch_size"] == 16
-    # The exact comparison deepspeed._batch_assertion makes must now succeed.
-    assert cfg["train_batch_size"] > 0
+    # train_batch_size must NOT be pinned to a world-size-scaled value: at zero.Init
+    # DeepSpeed sees world_size==1 and would reject 16 != 1*8*1. Leaving it None lets
+    # DeepSpeed derive a self-consistent value from whatever world size it sees.
+    assert cfg["train_batch_size"] is None
 
 
-def test_resolve_auto_batch_defaults_world_size_to_one(monkeypatch):
+def test_resolve_auto_batch_leaves_train_batch_unset_regardless_of_world_size(monkeypatch):
     monkeypatch.delenv("WORLD_SIZE", raising=False)
     trainer = _fake_trainer(micro=2, accum=4)
     cfg = BaseTrainer._resolve_ds_auto_batch(trainer, {"train_batch_size": "auto"})
-    assert cfg["train_batch_size"] == 8  # 2 * 4 * 1
+    assert cfg["train_micro_batch_size_per_gpu"] == 2
+    assert cfg["gradient_accumulation_steps"] == 4
+    assert cfg["train_batch_size"] is None
 
 
 def test_resolve_auto_batch_reads_path_and_does_not_mutate_input(tmp_path, monkeypatch):
@@ -104,7 +106,9 @@ def test_resolve_auto_batch_reads_path_and_does_not_mutate_input(tmp_path, monke
     trainer = _fake_trainer(micro=1, accum=8)
 
     cfg = BaseTrainer._resolve_ds_auto_batch(trainer, str(cfg_path))
-    assert cfg["train_batch_size"] == 32  # 1 * 8 * 4
+    assert cfg["train_batch_size"] is None
+    assert cfg["train_micro_batch_size_per_gpu"] == 1
+    assert cfg["gradient_accumulation_steps"] == 8
     assert cfg["zero_optimization"]["stage"] == 3
     # The original file on disk is untouched.
     assert json.loads(cfg_path.read_text())["train_batch_size"] == "auto"


### PR DESCRIPTION
The prior auto-batch fix (34c2c5e) pinned train_batch_size = micro * accum
* WORLD_SIZE in the config registered before from_pretrained. But DeepSpeed's _batch_assertion enforces train_batch_size == micro * grad_acc * world_size, and at zero.Init time -- invoked inside from_pretrained -- DeepSpeed's comm backend isn't initialized yet, so it reads world_size == 1 regardless of the real WORLD_SIZE. On a 2-GPU run that produced "16 != 1 * 8 * 1" and failed every non-quantized ZeRO-3 load (this time after the load actually started, since the earlier "auto" TypeError was already resolved).

Set only train_micro_batch_size_per_gpu and gradient_accumulation_steps, and leave train_batch_size unset (None) so DeepSpeed derives it as micro * grad_acc * world_size using whatever world size it sees -- internally consistent in both the early zero.Init context and later. The HF Trainer still builds its own config from the original deepspeed_config path, so nothing downstream changes.