### PR TITLE
Add VLM training dataset examples for smoke testing

### DIFF
--- a/recipes/training/sft_vlm/example_training_data_bytes.csv
+++ b/recipes/training/sft_vlm/example_training_data_bytes.csv
@@ -1,6 +1,21 @@
 image_bytes,question,response
 recipes/training/sft_vlm/image_bytes/cat_chonk.bin,Describe the animal in this image.,"A large, fluffy cat is sitting and looking toward the camera with an alert expression."
+recipes/training/sft_vlm/image_bytes/cat_chonk.bin,What is the cat doing?,The cat is sitting upright and gazing directly toward the viewer.
+recipes/training/sft_vlm/image_bytes/cat_chonk.bin,Is this a cat or a dog?,It is a cat.
+recipes/training/sft_vlm/image_bytes/cat_chonk.bin,Write a short caption for this image.,"A big, fluffy cat posing for the camera."
 recipes/training/sft_vlm/image_bytes/bee.bin,What is shown in this photo?,A close-up macro photograph of a bee resting on a pink flower.
+recipes/training/sft_vlm/image_bytes/bee.bin,What insect is in the image?,A bee.
+recipes/training/sft_vlm/image_bytes/bee.bin,What is the bee resting on?,It is resting on a pink flower.
+recipes/training/sft_vlm/image_bytes/bee.bin,Describe this image in one sentence.,"A bee perched on a pink bloom, captured in sharp macro detail."
 recipes/training/sft_vlm/image_bytes/cat.bin,What animal is in this image?,"There is a cat in the image, shown in close-up."
+recipes/training/sft_vlm/image_bytes/cat.bin,How many animals are in the image?,"There is one animal, a single cat."
+recipes/training/sft_vlm/image_bytes/cat.bin,Is the image a close-up or a wide shot?,It is a close-up shot of the cat.
+recipes/training/sft_vlm/image_bytes/cat.bin,Provide a brief caption.,A close-up portrait of a cat.
 recipes/training/sft_vlm/image_bytes/cats.bin,How many animals are in this image and what are they?,There are two cats lying down and resting next to each other.
+recipes/training/sft_vlm/image_bytes/cats.bin,What are the cats doing?,The two cats are lying down and resting side by side.
+recipes/training/sft_vlm/image_bytes/cats.bin,Are there more than one animal in the image?,"Yes, there are two cats."
+recipes/training/sft_vlm/image_bytes/cats.bin,Caption this image.,Two cats relaxing next to one another.
 recipes/training/sft_vlm/image_bytes/beignets.bin,What food is shown in this image?,"A plate of beignets (square French doughnuts) dusted with powdered sugar, served alongside a cup of coffee."
+recipes/training/sft_vlm/image_bytes/beignets.bin,What is served alongside the pastries?,A cup of coffee is served alongside the beignets.
+recipes/training/sft_vlm/image_bytes/beignets.bin,Are these pastries sweet?,"Yes, they are dusted with powdered sugar."
+recipes/training/sft_vlm/image_bytes/beignets.bin,Describe the image briefly.,Powdered-sugar beignets on a plate with a cup of coffee.

--- a/recipes/training/sft_vlm/example_training_image_url.csv
+++ b/recipes/training/sft_vlm/example_training_image_url.csv
@@ -1,6 +1,21 @@
 image_url,question,response
 https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg,Describe the animal in this image.,"A large, fluffy cat is sitting and looking toward the camera with an alert expression."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg,What is the cat doing?,The cat is sitting upright and gazing directly toward the viewer.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg,Is this a cat or a dog?,It is a cat.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg,Write a short caption for this image.,"A big, fluffy cat posing for the camera."
 https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg,What is shown in this photo?,A close-up macro photograph of a bee resting on a pink flower.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg,What insect is in the image?,A bee.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg,What is the bee resting on?,It is resting on a pink flower.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg,Describe this image in one sentence.,"A bee perched on a pink bloom, captured in sharp macro detail."
 https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cat.png,What animal is in this image?,"There is a cat in the image, shown in close-up."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cat.png,How many animals are in the image?,"There is one animal, a single cat."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cat.png,Is the image a close-up or a wide shot?,It is a close-up shot of the cat.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cat.png,Provide a brief caption.,A close-up portrait of a cat.
 https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png,How many animals are in this image and what are they?,There are two cats lying down and resting next to each other.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png,What are the cats doing?,The two cats are lying down and resting side by side.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png,Are there more than one animal in the image?,"Yes, there are two cats."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png,Caption this image.,Two cats relaxing next to one another.
 https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png,What food is shown in this image?,"A plate of beignets (square French doughnuts) dusted with powdered sugar, served alongside a cup of coffee."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png,What is served alongside the pastries?,A cup of coffee is served alongside the beignets.
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png,Are these pastries sweet?,"Yes, they are dusted with powdered sugar."
+https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png,Describe the image briefly.,Powdered-sugar beignets on a plate with a cup of coffee.

--- a/recipes/training/sft_vlm/example_training_s3_data.csv
+++ b/recipes/training/sft_vlm/example_training_s3_data.csv
@@ -1,6 +1,21 @@
 image_url,question,response
 s3://your-bucket/datasets/vlm_images/cat_chonk.png,Describe the animal in this image.,"A large, fluffy cat is sitting and looking toward the camera with an alert expression."
+s3://your-bucket/datasets/vlm_images/cat_chonk.png,What is the cat doing?,The cat is sitting upright and gazing directly toward the viewer.
+s3://your-bucket/datasets/vlm_images/cat_chonk.png,Is this a cat or a dog?,It is a cat.
+s3://your-bucket/datasets/vlm_images/cat_chonk.png,Write a short caption for this image.,"A big, fluffy cat posing for the camera."
 s3://your-bucket/datasets/vlm_images/bee.png,What is shown in this photo?,A close-up macro photograph of a bee resting on a pink flower.
+s3://your-bucket/datasets/vlm_images/bee.png,What insect is in the image?,A bee.
+s3://your-bucket/datasets/vlm_images/bee.png,What is the bee resting on?,It is resting on a pink flower.
+s3://your-bucket/datasets/vlm_images/bee.png,Describe this image in one sentence.,"A bee perched on a pink bloom, captured in sharp macro detail."
 s3://your-bucket/datasets/vlm_images/cat.png,What animal is in this image?,"There is a cat in the image, shown in close-up."
+s3://your-bucket/datasets/vlm_images/cat.png,How many animals are in the image?,"There is one animal, a single cat."
+s3://your-bucket/datasets/vlm_images/cat.png,Is the image a close-up or a wide shot?,It is a close-up shot of the cat.
+s3://your-bucket/datasets/vlm_images/cat.png,Provide a brief caption.,A close-up portrait of a cat.
 s3://your-bucket/datasets/vlm_images/cats.png,How many animals are in this image and what are they?,There are two cats lying down and resting next to each other.
+s3://your-bucket/datasets/vlm_images/cats.png,What are the cats doing?,The two cats are lying down and resting side by side.
+s3://your-bucket/datasets/vlm_images/cats.png,Are there more than one animal in the image?,"Yes, there are two cats."
+s3://your-bucket/datasets/vlm_images/cats.png,Caption this image.,Two cats relaxing next to one another.
 s3://your-bucket/datasets/vlm_images/beignets.png,What food is shown in this image?,"A plate of beignets (square French doughnuts) dusted with powdered sugar, served alongside a cup of coffee."
+s3://your-bucket/datasets/vlm_images/beignets.png,What is served alongside the pastries?,A cup of coffee is served alongside the beignets.
+s3://your-bucket/datasets/vlm_images/beignets.png,Are these pastries sweet?,"Yes, they are dusted with powdered sugar."
+s3://your-bucket/datasets/vlm_images/beignets.png,Describe the image briefly.,Powdered-sugar beignets on a plate with a cup of coffee.

--- a/recipes/training/sft_vlm/example_training_s3_data_bytes.csv
+++ b/recipes/training/sft_vlm/example_training_s3_data_bytes.csv
@@ -1,6 +1,21 @@
 image_bytes,question,response
 s3://your-bucket/datasets/image_bytes/cat_chonk.bin,Describe the animal in this image.,"A large, fluffy cat is sitting and looking toward the camera with an alert expression."
+s3://your-bucket/datasets/image_bytes/cat_chonk.bin,What is the cat doing?,The cat is sitting upright and gazing directly toward the viewer.
+s3://your-bucket/datasets/image_bytes/cat_chonk.bin,Is this a cat or a dog?,It is a cat.
+s3://your-bucket/datasets/image_bytes/cat_chonk.bin,Write a short caption for this image.,"A big, fluffy cat posing for the camera."
 s3://your-bucket/datasets/image_bytes/bee.bin,What is shown in this photo?,A close-up macro photograph of a bee resting on a pink flower.
+s3://your-bucket/datasets/image_bytes/bee.bin,What insect is in the image?,A bee.
+s3://your-bucket/datasets/image_bytes/bee.bin,What is the bee resting on?,It is resting on a pink flower.
+s3://your-bucket/datasets/image_bytes/bee.bin,Describe this image in one sentence.,"A bee perched on a pink bloom, captured in sharp macro detail."
 s3://your-bucket/datasets/image_bytes/cat.bin,What animal is in this image?,"There is a cat in the image, shown in close-up."
+s3://your-bucket/datasets/image_bytes/cat.bin,How many animals are in the image?,"There is one animal, a single cat."
+s3://your-bucket/datasets/image_bytes/cat.bin,Is the image a close-up or a wide shot?,It is a close-up shot of the cat.
+s3://your-bucket/datasets/image_bytes/cat.bin,Provide a brief caption.,A close-up portrait of a cat.
 s3://your-bucket/datasets/image_bytes/cats.bin,How many animals are in this image and what are they?,There are two cats lying down and resting next to each other.
+s3://your-bucket/datasets/image_bytes/cats.bin,What are the cats doing?,The two cats are lying down and resting side by side.
+s3://your-bucket/datasets/image_bytes/cats.bin,Are there more than one animal in the image?,"Yes, there are two cats."
+s3://your-bucket/datasets/image_bytes/cats.bin,Caption this image.,Two cats relaxing next to one another.
 s3://your-bucket/datasets/image_bytes/beignets.bin,What food is shown in this image?,"A plate of beignets (square French doughnuts) dusted with powdered sugar, served alongside a cup of coffee."
+s3://your-bucket/datasets/image_bytes/beignets.bin,What is served alongside the pastries?,A cup of coffee is served alongside the beignets.
+s3://your-bucket/datasets/image_bytes/beignets.bin,Are these pastries sweet?,"Yes, they are dusted with powdered sugar."
+s3://your-bucket/datasets/image_bytes/beignets.bin,Describe the image briefly.,Powdered-sugar beignets on a plate with a cup of coffee.


### PR DESCRIPTION
## Summary

  - Expand example VLM training CSVs from 5 to 20 rows each (4 QA pairs per image) to provide more realistic smoke test coverage
  - Add varied question types (description, identification, captioning, yes/no) across all dataset formats (image URL, S3 URL, local bytes, S3 bytes)