### PR TITLE
fix(s3): treat failed model uploads as failures instead of reporting success

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.35"
+version = "0.1.36"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -138,11 +138,28 @@ class S3UploadCallback(TrainerCallback):
         # the binary isn't installed, instead of mid-training on the first save.
         _resolve_uploader(self.uploader)
         self._upload_threads: list[threading.Thread] = []
+        # Exceptions raised inside upload threads are captured here, since
+        # Thread.join() does NOT propagate them and would otherwise let a
+        # failed upload pass as success.
+        self._upload_errors: list[BaseException] = []
+        self._errors_lock = threading.Lock()
+
+    def _run_upload(self, **kwargs):
+        """Thread target that runs the upload and records any failure."""
+        try:
+            upload_directory_to_s3(**kwargs)
+        except BaseException as exc:  # noqa: BLE001 - re-raised on join
+            logger.error(
+                "S3 upload to s3://%s/%s failed: %s",
+                kwargs.get("bucket"), kwargs.get("s3_prefix"), exc,
+            )
+            with self._errors_lock:
+                self._upload_errors.append(exc)
 
     def _schedule_upload(self, local_dir: str, s3_prefix: str, delete_local: bool = False):
         """Start a background upload and track the thread."""
         t = threading.Thread(
-            target=upload_directory_to_s3,
+            target=self._run_upload,
             kwargs=dict(
                 local_dir=local_dir,
                 bucket=self.bucket,
@@ -158,10 +175,32 @@ class S3UploadCallback(TrainerCallback):
         self._upload_threads.append(t)
 
     def _wait_for_uploads(self, timeout_per_thread: float = 1800):
-        """Block until all background uploads finish."""
+        """Block until all background uploads finish.
+
+        Raises RuntimeError if any upload failed or did not complete within the
+        timeout, so a failed model/checkpoint upload is reported as a failure
+        instead of silently passing.
+        """
+        timed_out = []
         for t in self._upload_threads:
             t.join(timeout=timeout_per_thread)
+            if t.is_alive():
+                timed_out.append(t)
         self._upload_threads.clear()
+
+        with self._errors_lock:
+            errors = list(self._upload_errors)
+            self._upload_errors.clear()
+
+        if timed_out:
+            raise RuntimeError(
+                f"{len(timed_out)} S3 upload(s) did not finish within "
+                f"{timeout_per_thread}s; treating as failed."
+            )
+        if errors:
+            raise RuntimeError(
+                f"{len(errors)} S3 upload(s) failed; first error: {errors[0]}"
+            ) from errors[0]
 
     # -- Trainer hooks --
 


### PR DESCRIPTION
  ## Problem

  When uploading a fine-tuned model (or checkpoint) to S3 failed, the training run still reported **success**. It should have failed.

  ## Root cause

  `S3UploadCallback` runs uploads in background threads via `_schedule_upload`. `_wait_for_uploads` only called `Thread.join()` — but `Thread.join()` does **not** propagate exceptions raised inside the thread. So when `upload_directory_to_s3` raised (s5cmd non-zero
  exit, boto3 error, etc.), the thread died silently, `join()` returned normally, and `on_train_end` completed cleanly → the run reported success despite a failed upload.

  ## Fix

  - Wrap the upload in a new `_run_upload` thread target that catches exceptions, logs them, and records them in a lock-protected `_upload_errors` list.
  - `_wait_for_uploads` now re-raises a `RuntimeError` if any upload failed, so the failure propagates out of `on_train_end` and fails the run.
  - Also treat a thread still alive after the join timeout as a failure (previously a hung/timed-out upload passed silently too).