### PR TITLE
fix(config): remove dangling value_model_name reference left from PPO removal

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -56,7 +56,6 @@ class ModelConfig:
             "load_in_8bit": self.load_in_8bit,
             "load_in_4bit": self.load_in_4bit,
             "use_flash_attention": self.use_flash_attention,
-            "value_model_name": self.value_model_name,
             "bnb_4bit_compute_dtype": self.bnb_4bit_compute_dtype,
             "bnb_4bit_quant_type": self.bnb_4bit_quant_type,
             "bnb_4bit_use_double_quant": self.bnb_4bit_use_double_quant,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.36"
+version = "0.1.37"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
  ## Problem
  Every training run crashes at startup with:
  \`\`\`
  AttributeError: 'ModelConfig' object has no attribute 'value_model_name'. Did you mean: 'base_model_name'?
    File ".../core/config.py", line 59, in to_dict
  \`\`\`

  ## Root cause
  `ModelConfig.to_dict()` still referenced `self.value_model_name`, but the `value_model_name` field was removed along with PPO (#75). The dangling reference in `to_dict()` was missed. It fires as soon as `trainers/train.py` calls `config.model.to_dict()` — before
  training begins — failing all Ray workers.

  ## Fix
  Remove the orphaned `"value_model_name": self.value_model_name,` line. Verified no other references to `value_model_name` remain in the codebase.