### PR TITLE
feat(sft_vlm): support multiple image and text columns

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -83,17 +83,18 @@ class DatasetInfo:
     chosen_column: str = "chosen"
     rejected_column: str = "rejected"
     answer_column: str = "answer"
+    # Text columns used to build each example. For sft_vlm, dataset_columns names
+    # the columns whose values fill the system_prompt .format() template (e.g.
+    # dataset_columns: [question, response] with a "...{question}...{response}"
+    # template). When no system_prompt is set, the column values are concatenated
+    # in order. The result is one training turn (no prompt/completion masking).
     dataset_columns: Optional[List[str]] = None
 
-    # Multimodal (sft_vlm) columns. image_column holds an HTTP(S) URL, a local
-    # path, raw bytes, a PIL image, or a list thereof (multiple images per row).
-    # question_column / response_column hold the user prompt and target answer.
-    # Alternatively, messages_column points at a column already in conversational
-    # format (a list of {role, content} dicts) -- when set it takes precedence.
-    image_column: Optional[str] = None
-    question_column: str = "question"
-    response_column: str = "response"
-    messages_column: Optional[str] = None
+    # Multimodal (sft_vlm) image columns. image_columns names one or more columns,
+    # each holding an HTTP(S) URL, an s3:// URI, a local path, raw bytes, a PIL
+    # image, or a list thereof. Every image found across these columns (in order)
+    # is attached to the row, so a single row may carry multiple images.
+    image_columns: Optional[List[str]] = None
 
     # S3 connection overrides (only used when name starts with s3://).
     # When unset, boto3 uses its default credential/region resolution chain.
@@ -141,10 +142,7 @@ class DataConfig:
                     "rejected_column": ds.rejected_column,
                     "answer_column": ds.answer_column,
                     "dataset_columns": ds.dataset_columns,
-                    "image_column": ds.image_column,
-                    "question_column": ds.question_column,
-                    "response_column": ds.response_column,
-                    "messages_column": ds.messages_column,
+                    "image_columns": ds.image_columns,
                     "s3_region": ds.s3_region,
                     "s3_endpoint_url": ds.s3_endpoint_url,
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.37"
+version = "0.1.38"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/sft_vlm/qwen2_5_vl_3b_lora.yaml
+++ b/recipes/training/sft_vlm/qwen2_5_vl_3b_lora.yaml
@@ -25,13 +25,13 @@ model:
 
 data:
   datasets:
-    # image_column values may be HTTP(S) URLs, local paths, or s3:// URIs
-    # (e.g. s3://your-bucket/images/cat.png). s3:// images use the
-    # image_s3_region / image_s3_endpoint_url settings below.
+    # image_columns lists one or more image columns; each value may be an HTTP(S)
+    # URL, a local path, or an s3:// URI (e.g. s3://your-bucket/images/cat.png).
+    # s3:// images use the image_s3_region / image_s3_endpoint_url settings below.
+    # dataset_columns lists the text columns that fill the system_prompt template.
     - name: "data/sft_vlm/example_training_image_url.csv"
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
 
   image_cache_dir: "data/vlm_image_cache"
   image_fetch_timeout: 15
@@ -42,9 +42,10 @@ data:
   image_s3_region: null
   image_s3_endpoint_url: null
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_image_bytes.yaml
+++ b/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_image_bytes.yaml
@@ -28,21 +28,22 @@ model:
 
 data:
   datasets:
-    # image_bytes points at a local binary file (escaped-bytes text form) under
-    # image_bytes/. Paths resolve relative to the repo root (the run's CWD).
+    # Each image_columns value points at a local binary file (escaped-bytes text
+    # form) under image_bytes/. Paths resolve relative to the repo root (the run's
+    # CWD). dataset_columns lists the text columns that fill the system_prompt.
     - name: "data/sft_vlm/example_training_data_bytes.csv"
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
 
   # Local files are decoded in place -- no fetch -- so image_cache_dir /
   # image_fetch_* / image_s3_* don't apply here. Only max_image_pixels still
   # runs (post-decode) to bound the vision-token count.
   max_image_pixels: 262144         # ~0.25MP keeps the smoke test light
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_s3_file.yaml
+++ b/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_s3_file.yaml
@@ -30,13 +30,13 @@ data:
   datasets:
     # S3 dataset loading: set name to an s3:// URI ending in .jsonl/.json/.csv/.parquet.
     # boto3 credentials resolve from the environment (IAM role, AWS_ACCESS_KEY_ID, etc.).
-    # Expected schema: {"image_url": "...", "question": "...", "response": "..."}
-    # (the same schema as data/sft_vlm/example_training_image_url.csv). The image_url
-    # column may hold an HTTP(S) URL, a local path, or an s3:// URI (e.g. s3://your-bucket/images/cat.png).
+    # Expected schema: {"image": "...", "question": "...", "response": "..."}
+    # (the same schema as data/sft_vlm/example_training_image_url.csv). Each
+    # image_columns value may hold an HTTP(S) URL, a local path, or an s3:// URI
+    # (e.g. s3://your-bucket/images/cat.png).
     - name: "s3://your-bucket/datasets/example_training_s3_data.csv"  # S3 URI to the dataset file (required)
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
       s3_region: null          # AWS region override for the dataset file (null = use AWS_DEFAULT_REGION)
       s3_endpoint_url: null     # Custom S3-compatible endpoint for the dataset file (null = AWS S3)
 
@@ -49,9 +49,10 @@ data:
   image_s3_region: null            # AWS region for s3:// images (null = use AWS_DEFAULT_REGION)
   image_s3_endpoint_url: null      # Custom S3-compatible endpoint for s3:// images (null = AWS S3)
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_s3_image_bytes.yaml
+++ b/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_s3_image_bytes.yaml
@@ -26,14 +26,13 @@ model:
 
 data:
   datasets:
-    # Dataset CSV in S3; its image_bytes column holds s3:// URIs to per-image
+    # Dataset CSV in S3; its image_columns column(s) hold s3:// URIs to per-image
     # binary files (escaped-bytes text form). s3_region / s3_endpoint_url govern
     # the dataset file; image_s3_region / image_s3_endpoint_url (below) govern
     # the s3:// image objects.
     - name: "s3://your-bucket/datasets/example_training_s3_data_bytes.csv"
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
       s3_region: null          # AWS region override for the dataset file (null = use AWS_DEFAULT_REGION)
       s3_endpoint_url: null     # Custom S3-compatible endpoint for the dataset file (null = AWS S3)
 
@@ -44,9 +43,10 @@ data:
   image_s3_region: null            # AWS region for s3:// images (null = use AWS_DEFAULT_REGION)
   image_s3_endpoint_url: null      # Custom S3-compatible endpoint for s3:// images (null = AWS S3)
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen3_vl_30b_a3b_lora.yaml
+++ b/recipes/training/sft_vlm/qwen3_vl_30b_a3b_lora.yaml
@@ -37,21 +37,21 @@ model:
 data:
   datasets:
     # Placeholder dataset (the 5-row smoke example). Replace with your real data;
-    # the schema is image_column (URL/path) + question/response columns, or a
-    # messages_column already in conversational format.
+    # the schema is one or more image_columns (URL/path/bytes) + the text columns
+    # listed in dataset_columns. List several image_columns for multi-image rows.
     - name: "data/sft_vlm/example_training_image_url.csv"
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
 
   image_cache_dir: "data/vlm_image_cache"
   image_fetch_timeout: 15
   image_fetch_retries: 3
   max_image_pixels: 1048576        # ~1MP; raise/lower to trade quality vs. memory
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen3_vl_30b_a3b_lora_s3_file.yaml
+++ b/recipes/training/sft_vlm/qwen3_vl_30b_a3b_lora_s3_file.yaml
@@ -44,13 +44,12 @@ data:
   datasets:
     # S3 dataset loading: set name to an s3:// URI ending in .jsonl/.json/.csv/.parquet.
     # boto3 credentials resolve from the environment (IAM role, AWS_ACCESS_KEY_ID, etc.).
-    # Expected JSONL schema: {"image_url": "...", "question": "...", "response": "..."}
-    # (the same schema as data/sft_vlm/example_training_image_url.csv), or a
-    # messages_column already in conversational format.
+    # Expected schema: {"image": "...", "question": "...", "response": "..."}
+    # (the same schema as data/sft_vlm/example_training_image_url.csv). List
+    # several image_columns for multi-image rows.
     - name: "s3://your-bucket/datasets/example_training_data_bytes.csv"  # S3 URI to the dataset file (required)
-      image_column: "image"
-      question_column: "question"
-      response_column: "response"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
       s3_region: null          # AWS region override (null = use AWS_DEFAULT_REGION)
       s3_endpoint_url: null     # Custom S3-compatible endpoint (null = AWS S3)
 
@@ -59,9 +58,10 @@ data:
   image_fetch_retries: 3
   max_image_pixels: 1048576        # ~1MP; raise/lower to trade quality vs. memory
 
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/recipes/training/sft_vlm/qwen3_vl_30b_a3b_qlora.yaml
+++ b/recipes/training/sft_vlm/qwen3_vl_30b_a3b_qlora.yaml
@@ -33,12 +33,11 @@ model:
 data:
   datasets:
     # Example dataset shipped with the repo: stable public image URLs + Q/A.
-    # Swap `name` for any HF/local/S3 dataset that has an image-URL column and
-    # question/response columns (or set messages_column for conversational data).
+    # Swap `name` for any HF/local/S3 dataset that has image column(s) and text
+    # columns. List several image_columns for multi-image rows.
     - name: "data/sft_vlm/example_training_image_url.csv"
-      image_column: "image"          # column holding an HTTP(S) URL (or a list of URLs)
-      question_column: "question"    # user prompt column
-      response_column: "response"    # target answer column
+      image_columns: ["image"]                  # column(s) holding image sources (URL/path/bytes)
+      dataset_columns: ["question", "response"] # text columns that fill the system_prompt template
 
   # Cache downloaded images on disk so they are not re-fetched every epoch.
   image_cache_dir: "data/vlm_image_cache"
@@ -48,9 +47,10 @@ data:
 
   # NOTE: max_length is forced to None internally for VLMs to avoid truncating
   # image placeholder tokens. The text knobs below are unused by sft_vlm.
-  # system_prompt is a .format() template; {question} and {response} are filled per row
-  # from question_column / response_column. {response} is the target answer -- include it
-  # only for labeling/eval-style data (it leaks the answer for generative SFT).
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -1,5 +1,4 @@
 import os, sys
-import json
 from typing import Optional, List, Any
 
 from datasets import concatenate_datasets
@@ -26,12 +25,15 @@ _VISION_TOWER_ATTRS = ("visual", "vision_tower", "vision_model")
 class SFTVLMTrainer(BaseTrainer):
     """Multimodal SFT trainer for vision-language models (image + text).
 
-    Loads a VLM via AutoModelForImageTextToText + AutoProcessor, fetches images
-    referenced by HTTP(S) URLs (or local paths) into PIL images, and delegates
-    to TRL's SFTTrainer. Because the processing class is a `ProcessorMixin`, TRL
-    treats this as a VLM run: it skips its own tokenization/preprocessing and
-    auto-selects `DataCollatorForVisionLanguageModeling`, which reads each row's
-    `messages` + `images` and builds `pixel_values`/`labels` on the fly.
+    Loads a VLM via AutoModelForImageTextToText + AutoProcessor, gathers the
+    images referenced across each dataset's `image_columns` (HTTP(S) URLs, s3://
+    URIs, local paths, or raw bytes -- one or many per row) into PIL images,
+    builds the text for each row from its `dataset_columns` via the
+    `system_prompt` template, and delegates to TRL's SFTTrainer. Because the
+    processing class is a `ProcessorMixin`, TRL treats this as a VLM run: it skips
+    its own tokenization/preprocessing and auto-selects
+    `DataCollatorForVisionLanguageModeling`, which reads each row's `messages` +
+    `images` and builds `pixel_values`/`labels` on the fly.
 
     Dataset rows are produced lazily via `Dataset.with_transform`, so images are
     decoded to PIL only at access time and the heterogeneous multimodal
@@ -105,37 +107,34 @@ class SFTVLMTrainer(BaseTrainer):
     def _normalize_dataset(self, dataset, dataset_info):
         """Map a raw dataset to a uniform, Arrow-friendly schema.
 
-        Output columns (all simple types so multiple datasets can be
-        concatenated and serialized safely):
-          _image_sources : list[str]  -- image URLs / local paths for the row
-          _question      : str        -- user prompt   (image_column path)
-          _response      : str        -- target answer (image_column path)
-          _messages_json : str        -- JSON of pre-built conversational
-                                          messages, or "" when not provided
+        Output columns (simple types so multiple datasets can be concatenated
+        and serialized safely):
+          _image_sources : list[str]  -- image sources gathered, in order, from
+                                          every image_columns column for the row
+          _text          : str        -- the full text built from dataset_columns
+                                          (via the system_prompt template, or by
+                                          concatenation when no template is set)
         """
-        image_column = dataset_info.image_column
-        messages_column = dataset_info.messages_column
-        q_col = dataset_info.question_column
-        r_col = dataset_info.response_column
+        image_columns = dataset_info.image_columns or []
+        dataset_columns = dataset_info.dataset_columns or []
+        system_prompt = self.config.data.system_prompt
 
         def fn(example):
-            raw = example.get(image_column) if image_column else None
-            if raw is None:
-                sources = []
-            elif isinstance(raw, (list, tuple)):
-                sources = [str(s) for s in raw if s is not None]
-            else:
-                sources = [str(raw)]
-
-            messages_json = ""
-            if messages_column and example.get(messages_column) is not None:
-                messages_json = json.dumps(example[messages_column])
+            # Gather image sources across every configured image column. Each
+            # column may hold a single source or a list of them.
+            sources = []
+            for col in image_columns:
+                raw = example.get(col)
+                if raw is None:
+                    continue
+                if isinstance(raw, (list, tuple)):
+                    sources.extend(str(s) for s in raw if s is not None)
+                else:
+                    sources.append(str(raw))
 
             return {
                 "_image_sources": sources,
-                "_question": str(example.get(q_col, "")),
-                "_response": str(example.get(r_col, "")),
-                "_messages_json": messages_json,
+                "_text": self._build_text(system_prompt, dataset_columns, example),
             }
 
         return dataset.map(fn, remove_columns=dataset.column_names)
@@ -172,66 +171,45 @@ class SFTVLMTrainer(BaseTrainer):
         new_size = (max(1, int(w * scale)), max(1, int(h * scale)))
         return img.resize(new_size)
 
-    def _render_system_prompt(self, template: str, question: str, response: str) -> str:
-        """Fill the system_prompt template with the row's question/response values.
+    def _build_text(self, template: Optional[str], dataset_columns: List[str], example) -> str:
+        """Build one text block for a row from its configured text columns.
 
-        Mirrors the text SFT trainer, whose ``system_prompt`` is a ``str.format``
-        template keyed by the dataset's column names. The placeholder names here
-        are the recipe's configured ``question_column`` / ``response_column`` -- a
-        column name is just a variable, so renaming the column renames the
-        placeholder (e.g. ``question_column: "query"`` -> use ``{query}``). Falls
-        back to the literal text if the template references an unknown key or is
-        malformed; double any literal braces as ``{{`` / ``}}``.
-
-        Note: ``response`` is also the assistant (target) turn, so referencing it
-        here duplicates that turn and has no value to fill at inference -- it suits
-        only labeling/eval-style data, not generative VLM SFT.
+        Mirrors the text SFT trainer: when ``system_prompt`` is set it is a
+        ``str.format`` template keyed by the dataset's column names -- a column
+        name is just a variable, so ``dataset_columns: [question, response]``
+        renders ``"...{question}...{response}"`` (double any literal braces as
+        ``{{`` / ``}}``). When no template is set, the column values are
+        concatenated in order. The whole text becomes a single training turn with
+        no prompt/completion masking, so include only what the model should learn
+        to produce. Falls back to the literal template if it references an unknown
+        key or is malformed.
         """
-        if not template:
-            return template
-        fmt = {key: question for key in self._sysprompt_question_keys}
-        fmt.update({key: response for key in self._sysprompt_response_keys})
-        try:
-            return template.format(**fmt)
-        except (KeyError, IndexError, ValueError) as e:
-            if not getattr(self, "_system_prompt_warn_emitted", False):
-                available = sorted(self._sysprompt_question_keys | self._sysprompt_response_keys)
-                self.logger.warning(
-                    f"system_prompt template not rendered ({e}); using literal text. "
-                    f"Available placeholders: {available}. Double any literal braces as {{{{ }}}}."
-                )
-                self._system_prompt_warn_emitted = True
-            return template
+        fmt = {col: example.get(col, "") for col in dataset_columns}
+        if template:
+            try:
+                return template.format(**fmt)
+            except (KeyError, IndexError, ValueError) as e:
+                if not getattr(self, "_text_warn_emitted", False):
+                    self.logger.warning(
+                        f"system_prompt template not rendered ({e}); using literal "
+                        f"text. Available placeholders: {sorted(fmt)}. Double any "
+                        f"literal braces as {{{{ }}}}."
+                    )
+                    self._text_warn_emitted = True
+                return template
+        return "\n".join(str(fmt[col]) for col in dataset_columns)
 
     def _make_transform(self):
         """Build the lazy with_transform callable (batched columnar input)."""
-        system_prompt = self.config.data.system_prompt
-        # Placeholder names come from the recipe's column config (a column name is
-        # just a variable); the union covers all datasets being concatenated.
-        self._sysprompt_question_keys = {di.question_column for di in self.config.data.datasets}
-        self._sysprompt_response_keys = {di.response_column for di in self.config.data.datasets}
-
         def transform(batch):
             out_messages, out_images = [], []
-            n = len(batch["_image_sources"])
-            for i in range(n):
-                images = self._fetch_images(batch["_image_sources"][i])
-
-                messages_json = batch["_messages_json"][i]
-                if messages_json:
-                    messages = json.loads(messages_json)
-                else:
-                    # Raw-string content; TRL's collator inserts the right number
-                    # of image placeholders into the first user message.
-                    messages = []
-                    if system_prompt:
-                        content = self._render_system_prompt(
-                            system_prompt, batch["_question"][i], batch["_response"][i]
-                        )
-                        messages.append({"role": "system", "content": content})
-                    messages.append({"role": "user", "content": batch["_question"][i]})
-                    messages.append({"role": "assistant", "content": batch["_response"][i]})
-
+            for text, sources in zip(batch["_text"], batch["_image_sources"]):
+                images = self._fetch_images(sources)
+                # A single turn carrying the full templated text. Raw-string
+                # content lets TRL's vision collator insert one image placeholder
+                # per image into the message. Labels cover the whole sequence (no
+                # prompt/completion masking), mirroring the text SFT trainer.
+                messages = [{"role": "user", "content": text}]
                 out_messages.append(messages)
                 out_images.append(images)
             return {"messages": out_messages, "images": out_images}
@@ -259,6 +237,8 @@ class SFTVLMTrainer(BaseTrainer):
             def is_valid(example):
                 if not example["_image_sources"]:
                     return False
+                if not example["_text"].strip():
+                    return False
                 try:
                     self._fetch_images(example["_image_sources"])
                     return True
@@ -273,7 +253,7 @@ class SFTVLMTrainer(BaseTrainer):
             if skipped > 0:
                 self.logger.warning(
                     f"Skipped {skipped} examples from {dataset_info.name} "
-                    f"(missing image column or unfetchable images)"
+                    f"(no images, empty text, or unfetchable images)"
                 )
 
             normalized.append(ds)


### PR DESCRIPTION
Replace the fixed image_column/question_column/response_column (and messages_column) on DatasetInfo with image_columns + dataset_columns:

- image_columns: list of columns, each holding one or many image sources (URL / s3:// / local path / bytes), all gathered per row -> multi-image.
- dataset_columns: text columns that fill the system_prompt .format() template (or are concatenated when no template is set), mirroring the text SFT trainer. The rendered text is one training turn with no prompt/completion masking.

Rewrites the trainer's _normalize_dataset/_make_transform, replaces _render_system_prompt with _build_text, drops empty-text rows, and updates all 7 sft_vlm recipes to the new fields.