### PR TITLE
feat(inference): support multiple image columns for VLM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,23 +402,4 @@ limitations under the License.
 name = "FAI-RL"
 version = "X.Y.Z"  # Increment version
 ```
-
-2. **Build and publish**:
-```bash
-# Install build tools
-pip install --upgrade pip build twine
-
-# Clean previous builds
-rm -rf dist/ build/ *.egg-info
-
-# Build the package
-python -m build
-
-# Upload to PyPI (requires credentials)
-python -m twine upload dist/*
-
-# Or upload to test PyPi (requires credentials)
-python -m twine upload --repository testpypi dist/*
-```
-
 </details>

--- a/core/config.py
+++ b/core/config.py
@@ -303,12 +303,14 @@ class InferenceConfig:
     response_column: str = "response"
     checkpoint_column: str = "checkpoint"  # Column name for checkpoint identifier in multi-checkpoint inference
 
-    # Multimodal (VLM) inference. Setting image_column enables VLM mode: it names
-    # the dataset column holding an image URL / local path (or a list of them) for
-    # each row. The image(s) are fetched into PIL and fed to the processor
-    # alongside the templated text prompt. The fetch knobs mirror DataConfig's.
-    # When image_column is unset, inference runs text-only exactly as before.
-    image_column: Optional[str] = None
+    # Multimodal (VLM) inference. Setting image_columns enables VLM mode: it names
+    # one or more dataset columns, each holding an HTTP(S) URL, an s3:// URI, a
+    # local path, raw bytes, or a list thereof. Every image found across these
+    # columns (in order) is fetched into PIL and fed to the processor alongside the
+    # templated text prompt, so a single row may carry multiple images. The fetch
+    # knobs mirror DataConfig's. When image_columns is unset, inference runs
+    # text-only exactly as before. Mirrors the sft_vlm trainer's image_columns.
+    image_columns: Optional[List[str]] = None
     image_cache_dir: Optional[str] = None
     image_fetch_timeout: int = 10
     image_fetch_retries: int = 3

--- a/inference/README.md
+++ b/inference/README.md
@@ -34,12 +34,14 @@ CUDA_VISIBLE_DEVICES=0 fai-rl-inference --recipe recipes/inference/qwen2_5_vl_3b
 
 ### Multimodal (VLM) Inference
 
-To run inference on a vision-language model fine-tuned with the `sft_vlm` algorithm, set **`image_column`** in the recipe. Its presence switches inference into VLM mode: for each row, the image URL/path in that column is fetched into a PIL image and fed to the model alongside the templated text prompt. See `recipes/inference/qwen2_5_vl_3b.yaml`.
+To run inference on a vision-language model fine-tuned with the `sft_vlm` algorithm, set **`image_columns`** in the recipe. Its presence switches inference into VLM mode: for each row, the image URL/path in those columns is fetched into a PIL image and fed to the model alongside the templated text prompt. See `recipes/inference/qwen2_5_vl_3b.yaml`.
 
 Key VLM recipe fields (under `inference:`):
-- `image_column` — dataset column holding an image URL / local path (or a list of them). **Required to enable VLM mode.**
+- `image_columns` — list of dataset columns, each holding an image URL / `s3://` URI / local path (or a list of them). Every image found across these columns (in order) is fed to the model, so a row can carry **multiple images**. **Required to enable VLM mode.** Mirrors the `sft_vlm` trainer's `image_columns`.
 - `image_cache_dir`, `image_fetch_timeout`, `image_fetch_retries`, `max_image_pixels` — image-fetch settings (mirror the training recipe).
-- `system_prompt` — prompt template (filled per row from `dataset_columns`); becomes the user text shown with the image.
+- `system_prompt` — prompt template (filled per row from `dataset_columns`); becomes the user text shown with the image(s).
+
+For multiple images per row, list more than one column (e.g. `image_columns: ["image_a", "image_b"]`) — the processor receives one image placeholder per fetched image, in column order. See `recipes/inference/qwen2_5_vl_3b_multi_image.yaml`.
 
 VLM mode loads the model as `AutoModelForImageTextToText` + `AutoProcessor`, automatically detects and merges PEFT/LoRA adapters, and supports the same multi-checkpoint, CSV-output, and S3-upload workflow as text models. It is **local-model only** — API endpoints are not supported for VLMs.
 

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -352,8 +352,8 @@ def generate_response(model, tokenizer, prompt: str, config):
 
 
 def is_vlm_inference(config) -> bool:
-    """VLM mode is enabled when the recipe sets a non-empty image_column."""
-    return bool(getattr(config, "image_column", None))
+    """VLM mode is enabled when the recipe sets a non-empty image_columns."""
+    return bool(getattr(config, "image_columns", None))
 
 
 def load_vlm_model_and_processor(config):
@@ -432,18 +432,22 @@ def _maybe_downscale_image(img, max_pixels):
 
 
 def fetch_example_images(config, example):
-    """Fetch the image(s) referenced by config.image_column for one dataset row.
+    """Fetch the image(s) referenced by config.image_columns for one dataset row.
 
-    The column may hold a single URL/path or a list of them. Returns a list of
-    RGB PIL images (possibly empty), each optionally downscaled to max_image_pixels.
+    image_columns lists one or more columns; each cell may hold a single URL/path
+    or a list of them. Every image found across the columns (in order) is gathered,
+    so a single row may carry multiple images. Returns a list of RGB PIL images
+    (possibly empty), each optionally downscaled to max_image_pixels.
     """
-    raw = example.get(config.image_column)
-    if raw is None:
-        sources = []
-    elif isinstance(raw, (list, tuple)):
-        sources = [str(s) for s in raw if s is not None]
-    else:
-        sources = [str(raw)]
+    sources = []
+    for col in (config.image_columns or []):
+        raw = example.get(col)
+        if raw is None:
+            continue
+        elif isinstance(raw, (list, tuple)):
+            sources.extend(str(s) for s in raw if s is not None)
+        else:
+            sources.append(str(raw))
 
     images = []
     for s in sources:
@@ -501,12 +505,12 @@ def run_inference(config, debug=False):
     use_api = (hasattr(config, 'model') and config.model is not None) and \
               (hasattr(config, 'api_key') and config.api_key is not None)
 
-    # Multimodal (VLM) mode is enabled by setting image_column in the recipe.
+    # Multimodal (VLM) mode is enabled by setting image_columns in the recipe.
     is_vlm = is_vlm_inference(config)
     if is_vlm and use_api:
         raise ValueError(
-            "VLM inference (image_column set) is only supported for local models, "
-            "not API endpoints. Remove image_column or use model_paths."
+            "VLM inference (image_columns set) is only supported for local models, "
+            "not API endpoints. Remove image_columns or use model_paths."
         )
 
     # Determine checkpoint paths to process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.38"
+version = "0.1.39"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/inference/qwen2_5_vl_3b.yaml
+++ b/recipes/inference/qwen2_5_vl_3b.yaml
@@ -1,9 +1,10 @@
 # Inference for a fine-tuned Qwen2.5-VL (multimodal) checkpoint.
 #
-# Setting `image_column` switches inference into VLM mode: for each row the image
-# URL/path in that column is fetched into a PIL image and fed to the model
+# Setting `image_columns` switches inference into VLM mode: for each row the image
+# URL/path in those columns is fetched into a PIL image and fed to the model
 # alongside the templated text prompt. Use this after training with the sft_vlm
-# algorithm (recipes/training/sft_vlm/qwen2_5_vl_3b_lora.yaml).
+# algorithm (recipes/training/sft_vlm/qwen2_5_vl_3b_lora.yaml). For a recipe that
+# feeds multiple images per row, see qwen2_5_vl_3b_multi_image.yaml.
 #
 # Run from the repo root:
 #   CUDA_VISIBLE_DEVICES=0 fai-rl-inference --recipe recipes/inference/qwen2_5_vl_3b.yaml
@@ -27,9 +28,10 @@ inference:
   dataset_columns: ["image_url", "question"]
   response_column: "response"
 
-  # Multimodal config: image_column names the column holding the image URL/path
-  # (or a list of them). Its presence is what enables VLM inference.
-  image_column: "image_url"
+  # Multimodal config: image_columns lists the column(s) holding the image URL/path
+  # (each cell may be a single value or a list). Its presence enables VLM inference;
+  # all images found across the listed columns are fed to the model per row.
+  image_columns: ["image_url"]
   image_cache_dir: "data/vlm_image_cache"
   image_fetch_timeout: 15
   image_fetch_retries: 3

--- a/recipes/inference/qwen3_vl_30b_a3b.yaml
+++ b/recipes/inference/qwen3_vl_30b_a3b.yaml
@@ -1,8 +1,9 @@
 # Inference for a fine-tuned Qwen3-VL-30B-A3B (multimodal MoE) checkpoint.
 #
-# Setting `image_column` enables VLM mode: each row's image URL/path is fetched
+# Setting `image_columns` enables VLM mode: each row's image URL/path is fetched
 # into a PIL image and fed to the model alongside the templated text prompt.
 # Use this after training with recipes/training/sft_vlm/qwen3_vl_30b_a3b_lora.yaml.
+# For a recipe that feeds multiple images per row, see qwen2_5_vl_3b_multi_image.yaml.
 #
 # The 30B model is too large for one GPU; the inference engine loads it with
 # device_map="auto", which automatically shards the weights across all visible
@@ -29,9 +30,10 @@ inference:
   dataset_columns: ["image_url", "question"]
   response_column: "response"
 
-  # Multimodal config: image_column names the column holding the image URL/path
-  # (or a list of them). Its presence is what enables VLM inference.
-  image_column: "image_url"
+  # Multimodal config: image_columns lists the column(s) holding the image URL/path
+  # (each cell may be a single value or a list). Its presence enables VLM inference;
+  # all images found across the listed columns are fed to the model per row.
+  image_columns: ["image_url"]
   image_cache_dir: "data/vlm_image_cache"
   image_fetch_timeout: 15
   image_fetch_retries: 3


### PR DESCRIPTION
## Changes

Replace the singular image_column on InferenceConfig with image_columns (a list of columns), mirroring the sft_vlm trainer. Every image found across the listed columns is gathered per row, so a row can carry multiple images. Updates fetch_example_images/is_vlm_inference, the two existing VLM recipes, and the inference README. Also bumps version to 0.1.39 and trims the PyPI publish steps from the top-level README.