### PR TITLE
docs(sft_vlm): document multimodal SFT support and dataset options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A production-ready framework for training, inference, evaluation using advanced 
 
 FAI-RL provides a unified, extensible framework for fine-tuning language models with the state-of-the-art algorithms:
 
-- 🎯 **Supports Multiple RL Algorithms**: DPO, GRPO, GSPO implementations as well as support for Supervised Fine-Tuning and Continuous Pre-Training.
+- 🎯 **Supports Multiple RL Algorithms**: DPO, GRPO, GSPO implementations as well as support for Supervised Fine-Tuning (text and multimodal vision-language) and Continuous Pre-Training.
 - 🚀 **Production Ready**: Validated on AWS p4d instances with 8x A100 GPUs
 - 📦 **Simple Configuration**: YAML-based configs with CLI override support
 - ⚡ **Memory Efficient**: Full support for LoRA, QLoRA, and DeepSpeed ZeRO-3
@@ -40,7 +40,7 @@ We assume the user environment already has the necessary ML libraries
 installed (notably `torch`, with a CUDA build matching the host).
 
 ```bash
-uv pip install FAI-RL
+pip install FAI-RL
 ```
 
 ### Clone the Repository for Configuration Recipes
@@ -94,7 +94,7 @@ The default value (`https://api.wandb.ai`) points to the public W&B cloud. This 
 
 ### Training
 
-Train a model using any of the supported algorithms (CPT, SFT, DPO, GRPO, GSPO):
+Train a model using any of the supported algorithms (CPT, SFT, SFT_VLM, DPO, GRPO, GSPO):
 
 ```bash
 # Single GPU training with LoRA
@@ -138,12 +138,13 @@ fai-rl-eval --recipe recipes/evaluation/mmlu/llama3_3B.yaml --debug
 
 ## Supported Algorithms
 
-FAI-RL supports five training algorithms for language model fine-tuning:
+FAI-RL supports six training algorithms for language model fine-tuning:
 
 | Algorithm | Full Name | Description | Best For |
 |-----------|-----------|-------------|----------|
 | **CPT** | Continuous Pre-Training | Next-token prediction on raw text; no chat template | Domain adaptation, corpus ingestion |
 | **SFT** | Supervised Fine-Tuning | Direct supervised learning from labeled examples | Instruction fine-tuning and foundational model fine-tuning |
+| **SFT_VLM** | Multimodal Supervised Fine-Tuning | Supervised fine-tuning of vision-language models on `(image, text) -> response` data (supports multiple images per row) | Instruction-tuning VLMs, image understanding tasks |
 | **DPO** | Direct Preference Optimization | Alignment via preference learning without explicit reward models | Human preference alignment, chat model training |
 | **GRPO** | Group Relative Policy Optimization | Efficient preference learning with group-based comparison | Reasoning tasks, competitive response generation |
 | **GSPO** | Group Sequence Policy Optimization | Advanced sequence-level policy optimization | Complex multi-step reasoning, mathematical problem-solving |
@@ -255,7 +256,7 @@ FAI-RL/
 │       ├── mmlu.py
 │       └── gsm8k.py
 ├── recipes/                   # YAML configuration files
-│   ├── training/              # Training recipes (cpt/, sft/, dpo/, grpo/, gspo/)
+│   ├── training/              # Training recipes (cpt/, sft/, sft_vlm/, dpo/, grpo/, gspo/)
 │   ├── inference/             # Inference recipes
 │   └── evaluation/            # Evaluation recipes (mmlu/, gsm8k/)
 ├── configs/                   # DeepSpeed configurations

--- a/recipes/training/README.md
+++ b/recipes/training/README.md
@@ -33,11 +33,15 @@ YAML configuration files for all supported training algorithms. Each recipe is a
 | Recipe | Dataset source | Model source | Notes |
 |--------|---------------|--------------|-------|
 | `sft_vlm/qwen2_5_vl_3b_lora.yaml` | Local file (image URLs) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — small, for validating the pipeline |
+| `sft_vlm/qwen2_5_vl_3b_lora_image_bytes.yaml` | Local file (local image paths / raw bytes) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — images loaded from local `.bin` byte files |
+| `sft_vlm/qwen2_5_vl_3b_parquet.yaml` | Local Parquet (embedded images) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — HF-style `images: List[Image]` parquet, images decoded in-memory |
+| `sft_vlm/qwen2_5_vl_3b_lora_s3_file.yaml` | S3 file (image URLs) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — dataset file loaded from S3 |
+| `sft_vlm/qwen2_5_vl_3b_lora_s3_image_bytes.yaml` | S3 file (`s3://` image URIs) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — images fetched from S3 |
+| `sft_vlm/qwen3_vl_30b_a3b_lora.yaml` | Local file (image URLs) | HuggingFace Hub | LoRA, Qwen3-VL-30B-A3B MoE VLM |
 | `sft_vlm/qwen3_vl_30b_a3b_qlora.yaml` | Local file (image URLs) | HuggingFace Hub | QLoRA (4-bit), Qwen3-VL-30B-A3B MoE VLM |
-| `sft_vlm/qwen2_5_vl_3b_lora_s3_file.yaml` | S3 file (`s3://bucket/key.jsonl`, image URLs) | HuggingFace Hub | LoRA, Qwen2.5-VL-3B — dataset file loaded from S3 |
-| `sft_vlm/qwen3_vl_30b_a3b_lora_s3_file.yaml` | S3 file (`s3://bucket/key.jsonl`, image URLs) | HuggingFace Hub | LoRA, Qwen3-VL-30B-A3B MoE VLM — dataset file loaded from S3 |
+| `sft_vlm/qwen3_vl_30b_a3b_lora_s3_file.yaml` | S3 file (image URLs) | HuggingFace Hub | LoRA, Qwen3-VL-30B-A3B MoE VLM — dataset file loaded from S3 |
 
-Fine-tunes a vision-language model on `(image, prompt) -> response` data. Images are supplied as **HTTP(S) URLs** (or local paths) and fetched into PIL images at data-loading time. See [Multimodal datasets](#multimodal-datasets-sft_vlm) below.
+Fine-tunes a vision-language model on `(image, text) -> response` data, and supports **multiple images per row**. Images can be supplied as **HTTP(S) URLs**, local paths, `s3://` URIs, raw bytes, or **embedded in a Parquet file** (HuggingFace `images: List[Image]` schema) — all fetched/decoded into PIL images at data-loading time. See [Multimodal datasets](#multimodal-datasets-sft_vlm) below.
 
 ### DPO (Direct Preference Optimization)
 
@@ -98,16 +102,16 @@ All algorithms support three dataset sources. The source is selected by the valu
 | DPO | `prompt`, `chosen`, `rejected` |
 | GRPO | `prompt`, `answer` |
 | GSPO | `prompt`, `answer` |
-| SFT_VLM | `image_url`, `question`, `response` (see below) |
+| SFT_VLM | one or more image columns + one or more text columns (see below) |
 
-Column names are configurable — use `text_column`, `prompt_column`, `answer_column`, `chosen_column`, `rejected_column` in the dataset entry to remap them.
+Column names are configurable — use `text_column`, `prompt_column`, `answer_column`, `chosen_column`, `rejected_column` in the dataset entry to remap them. For **SFT_VLM**, images and text columns are named explicitly via `image_columns` and `dataset_columns` (see [Multimodal datasets](#multimodal-datasets-sft_vlm)).
 
 ### Multimodal datasets (SFT_VLM)
 
-The `sft_vlm` algorithm trains vision-language models on image + text. Each dataset row needs an image column plus a prompt/response pair. The shipped example is a CSV (any of `.csv` / `.jsonl` / `.json` / `.parquet`, HF Hub, or S3 works):
+The `sft_vlm` algorithm trains vision-language models on image + text. Each dataset row needs at least one image column plus one or more text columns. Columns are named via **`image_columns`** (a list) and **`dataset_columns`** (a list); a row can carry **multiple images**. The shipped example is a CSV (any of `.csv` / `.jsonl` / `.json` / `.parquet`, HF Hub, or S3 works):
 
 ```csv
-image_url,question,response
+image,question,response
 https://example.com/cat.jpg,What is in this image?,A cat sitting on a couch.
 ```
 
@@ -116,18 +120,22 @@ Configure the columns in the dataset entry, and the image-fetch behavior under `
 ```yaml
 data:
   datasets:
-    - name: "recipes/training/sft_vlm/example_training_image_url.csv"   # HF Hub / local / S3
-      image_column: "image_url"      # holds an HTTP(S) URL, a local path, or a list of them (multi-image)
-      question_column: "question"
-      response_column: "response"
-      # messages_column: "messages"  # alternative: a column already in conversational format
+    - name: "data/sft_vlm/example_training_image_url.csv"   # HF Hub / local / S3
+      image_columns: ["image"]              # one or more columns; each cell may hold an
+                                            # HTTP(S) URL, local path, s3:// URI, raw bytes,
+                                            # an embedded PIL image, or a list of any of these.
+                                            # List several columns for multi-image rows.
+      dataset_columns: ["question", "response"]  # text columns that fill the system_prompt template
   image_cache_dir: "data/vlm_image_cache"   # cache downloads so they aren't re-fetched each epoch
   image_fetch_timeout: 15
   image_fetch_retries: 3
   max_image_pixels: 1048576          # optional: downscale large images to bound vision tokens / memory
-  # system_prompt is a .format() template (like the text SFT recipes): {question} and
-  # {response} are filled per row. {response} leaks the target, so use it only for
-  # labeling/eval-style data. Double any literal braces as {{ }}.
+  image_s3_region: null              # override AWS region when an image value is an s3:// URI
+  image_s3_endpoint_url: null        # set for MinIO or other S3-compatible stores
+  # system_prompt is a .format() template (like the text SFT recipes), keyed by the
+  # dataset_columns names: {question} and {response} are filled per row. {response}
+  # leaks the target, so use it only for labeling/eval-style data. When no
+  # system_prompt is set, the dataset_columns values are concatenated instead.
   system_prompt: |
     You are a helpful multimodal assistant. Answer the user's question based on the image.
     Question: {question}
@@ -135,11 +143,13 @@ data:
 ```
 
 Notes:
-- `system_prompt` is a `str.format()` template supporting `{question}` and `{response}` (the configured question/response columns), mirroring the text-SFT templating above. Unknown placeholders fall back to the literal text.
-- Images are fetched from their URLs at startup; rows whose images can't be fetched/decoded are dropped (with a logged count).
-- A small example dataset of public image URLs ships at `recipes/training/sft_vlm/example_training_image_url.csv`. Any HF/local/S3 dataset with an image-URL column works — just point `name` at it.
+- `system_prompt` is a `str.format()` template whose placeholders are the `dataset_columns` names (e.g. `{question}`, `{response}`), mirroring the text-SFT templating above. Unknown placeholders fall back to the literal text. The rendered text is a single training turn (no prompt/completion masking).
+- **Multiple images per row:** list more than one column in `image_columns` (e.g. `["image_a", "image_b"]`), or put a list of image sources in a single cell. Every image found across the listed columns (in order) is attached to the row.
+- **Image sources:** each cell may be an HTTP(S) URL, a local path, an `s3://` URI, raw image bytes, or an embedded PIL image. Parquet files using the HuggingFace `images: List[Image]` schema (embedded PNG bytes) are decoded in-memory — no fetch happens. See `sft_vlm/qwen2_5_vl_3b_parquet.yaml`.
+- Images are fetched/decoded at startup; rows whose images can't be fetched/decoded (or that render empty text) are dropped, with a logged count.
+- Example datasets ship under `data/sft_vlm/`: `example_training_image_url.csv` (public image URLs), `example_training_data.csv` (local image paths), `example_training_data_bytes.csv` (local byte files), and `example_training_data.parquet` (embedded images). Any HF/local/S3 dataset with an image column works — just point `name` at it.
 - `data.max_length` is forced to `None` internally for VLMs so image placeholder tokens are never truncated.
-- **Network:** the training environment must be able to reach the image hosts **and** the HuggingFace Hub (for the model). If image hosts are blocked, pre-download images and use local paths in `image_column`.
+- **Network:** the training environment must be able to reach the image hosts **and** the HuggingFace Hub (for the model). If image hosts are blocked, pre-download images and use local paths (or an embedded-image parquet) in `image_columns`.
 
 ## Quick Start
 

--- a/trainers/README.md
+++ b/trainers/README.md
@@ -1,6 +1,8 @@
 # FAI-RL Training
 
-Training implementations supporting CPT (Continuous Pre-Training), SFT (Supervised Fine-Tuning), DPO (Direct Preference Optimization), GRPO (Group Relative Policy Optimization), and GSPO (Group Sequence Policy Optimization) methods.
+Training implementations supporting CPT (Continuous Pre-Training), SFT (Supervised Fine-Tuning), SFT_VLM (multimodal vision-language SFT), DPO (Direct Preference Optimization), GRPO (Group Relative Policy Optimization), and GSPO (Group Sequence Policy Optimization) methods.
+
+> **Multimodal (SFT_VLM):** image + text fine-tuning of vision-language models has its own recipes and dataset schema. See the [SFT_VLM recipe guide](../recipes/training/README.md#multimodal-datasets-sft_vlm).
 
 ## 🚀 Quick Start
 
@@ -85,7 +87,7 @@ Replace the following values for your specific use case:
   - **SFT**: Use `prompt_column` and `answer_column`
   - **DPO**: Use `prompt_column`, `chosen_column`, and `rejected_column`
   - **GRPO/GSPO**: Use `prompt_column` and `answer_column`
-- `training.algorithm` → choose from: `cpt`, `sft`, `dpo`, `grpo`, `gspo`
+- `training.algorithm` → choose from: `cpt`, `sft`, `sft_vlm`, `dpo`, `grpo`, `gspo`
 - `training.output_dir` → your desired model output directory
 - `wandb.*` → your Weights & Biases configuration (or set `enabled: false` to disable)
 


### PR DESCRIPTION
## Summary

  Documents the multimodal **SFT_VLM** algorithm across the README set. No code changes — docs only.

  FAI-RL now advertises six training algorithms (adding `sft_vlm`) and the multimodal
  dataset options are fully described, including multi-image rows and the range of
  supported image sources.

  ## Changes

  **`README.md`**
  - Note text **and multimodal vision-language** SFT in the feature list
  - Add `SFT_VLM` to the training-algorithm CLI examples and the supported-algorithms
    table (five → six algorithms)
  - Add `sft_vlm/` to the recipes tree in the project structure

  **`recipes/training/README.md`**
  - Expand the SFT_VLM recipe table (image-bytes, Parquet embedded-image, and S3
    variants for Qwen2.5-VL-3B and Qwen3-VL-30B-A3B)
  - Document **multiple images per row** and the full set of image sources:
    HTTP(S) URLs, local paths, `s3://` URIs, raw bytes, and Parquet-embedded images
    (HuggingFace `images: List[Image]` schema)
  - Switch dataset config to the `image_columns` / `dataset_columns` lists and document
    `image_s3_region` / `image_s3_endpoint_url`
  - Update `system_prompt` templating notes and the shipped example-dataset locations
    under `data/sft_vlm/`