### PR TITLE
feat(sft): add completion-only loss via split user/assistant prompts

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -87,7 +87,10 @@ class DatasetInfo:
     # the columns whose values fill the system_prompt .format() template (e.g.
     # dataset_columns: [question, response] with a "...{question}...{response}"
     # template). When no system_prompt is set, the column values are concatenated
-    # in order. The result is one training turn (no prompt/completion masking).
+    # in order. In legacy flat mode this is one training turn (loss over the whole
+    # sequence); in split mode (DataConfig.user_prompt/assistant_prompt set) these
+    # same columns fill the user/assistant/system templates and loss is
+    # completion-only.
     dataset_columns: Optional[List[str]] = None
 
     # Multimodal (sft_vlm) image columns. image_columns names one or more columns,
@@ -110,6 +113,18 @@ class DataConfig:
     max_prompt_length: int = 256
     remove_unused_columns: bool = False
     system_prompt: Optional[str] = None
+    # Split (chat) mode for SFT. When BOTH user_prompt and assistant_prompt are
+    # set, each row is built as a conversational prompt/completion pair instead of
+    # one flat turn, and loss is computed only on the assistant completion (the
+    # prompt is masked). Both are str.format() templates keyed by each dataset's
+    # dataset_columns, exactly like system_prompt (e.g. user_prompt: "{question}",
+    # assistant_prompt: "{response}"). In this mode system_prompt, if set, becomes
+    # a real system-role turn (still .format()-templated). When both are unset the
+    # trainers stay in the legacy flat-template mode (system_prompt is the single
+    # turn, loss over the whole sequence). Setting exactly one raises a config
+    # error (see __post_init__).
+    user_prompt: Optional[str] = None
+    assistant_prompt: Optional[str] = None
     dataset_num_proc: int = 1
 
     # Multimodal (sft_vlm) image-fetch settings. image_cache_dir, when set,
@@ -127,6 +142,22 @@ class DataConfig:
     # its default credential/region resolution chain.
     image_s3_region: Optional[str] = None
     image_s3_endpoint_url: Optional[str] = None
+
+    def __post_init__(self):
+        # Split (chat) mode is both-or-neither: rendering a prompt/completion pair
+        # requires both a user turn and an assistant turn.
+        if bool(self.user_prompt) != bool(self.assistant_prompt):
+            missing = "assistant_prompt" if self.user_prompt else "user_prompt"
+            raise ValueError(
+                "data.user_prompt and data.assistant_prompt must be set together "
+                f"(missing: {missing}). Set both to enable split/completion-only "
+                "mode, or neither to use the legacy flat system_prompt template."
+            )
+
+    @property
+    def split_mode(self) -> bool:
+        """True when user/assistant turns are split (completion-only loss)."""
+        return bool(self.user_prompt) and bool(self.assistant_prompt)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -151,6 +182,8 @@ class DataConfig:
             "max_prompt_length": self.max_prompt_length,
             "remove_unused_columns": self.remove_unused_columns,
             "system_prompt": self.system_prompt,
+            "user_prompt": self.user_prompt,
+            "assistant_prompt": self.assistant_prompt,
             "dataset_num_proc": self.dataset_num_proc,
             "image_cache_dir": self.image_cache_dir,
             "image_fetch_timeout": self.image_fetch_timeout,

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -744,7 +744,15 @@ class BaseTrainer(ABC):
                 pass
 
     def build_callbacks(self) -> list:
-        """Build trainer callbacks from config (e.g. S3 upload)."""
+        """Build trainer callbacks from config (e.g. S3 upload).
+
+        Also attaches the observation-only DebugCallback, which emits verbose
+        training diagnostics (config/arch, decoded first batches, tokenization
+        sanity, loss/masking stats, optimizer/scheduler, distributed layout,
+        memory/perf, and progress) at INFO. It never mutates training state and
+        every hook is wrapped so a logging failure can't crash the run. Set
+        FAI_RL_DISABLE_DEBUG_CALLBACK=1 to skip it.
+        """
         callbacks = []
         s3_cb = build_s3_callback(self.config.s3)
         if s3_cb is not None:
@@ -753,6 +761,13 @@ class BaseTrainer(ABC):
                 self.config.s3.bucket, self.config.s3.prefix,
             )
             callbacks.append(s3_cb)
+
+        if os.environ.get("FAI_RL_DISABLE_DEBUG_CALLBACK") != "1":
+            from utils.debug_callback import DebugCallback
+            callbacks.append(DebugCallback(self.logger, self.config))
+            self.logger.info(
+                "Debug diagnostics enabled (INFO); set FAI_RL_DISABLE_DEBUG_CALLBACK=1 to disable."
+            )
         return callbacks
 
     @abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.40"
+version = "0.1.41"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/README.md
+++ b/recipes/training/README.md
@@ -144,6 +144,13 @@ data:
 
 Notes:
 - `system_prompt` is a `str.format()` template whose placeholders are the `dataset_columns` names (e.g. `{question}`, `{response}`), mirroring the text-SFT templating above. Unknown placeholders fall back to the literal text. The rendered text is a single training turn (no prompt/completion masking).
+- **Completion-only loss (split user/assistant turns):** set **both** `user_prompt` and `assistant_prompt` (`str.format()` templates keyed by `dataset_columns`, just like `system_prompt`) to train on separate user and assistant turns with loss computed **only on the assistant response** — the prompt is masked. This is the standard recipe for instruction-tuned chat models. In this mode `system_prompt`, if set, becomes a real system-role turn. Setting just one of the two is a config error (both-or-neither). Omit both to keep the flat single-turn behavior above. See `sft_vlm/qwen2_5_vl_3b_lora_completion_loss.yaml`. Works the same way for the text `sft` algorithm.
+  ```yaml
+  data:
+    system_prompt: "You are a helpful multimodal assistant. Answer based on the image."
+    user_prompt: "{question}"        # inputs the model conditions on (masked)
+    assistant_prompt: "{response}"   # the only text the model is trained to produce
+  ```
 - **Multiple images per row:** list more than one column in `image_columns` (e.g. `["image_a", "image_b"]`), or put a list of image sources in a single cell. Every image found across the listed columns (in order) is attached to the row.
 - **Image sources:** each cell may be an HTTP(S) URL, a local path, an `s3://` URI, raw image bytes, or an embedded PIL image. Parquet files using the HuggingFace `images: List[Image]` schema (embedded PNG bytes) are decoded in-memory — no fetch happens. See `sft_vlm/qwen2_5_vl_3b_parquet.yaml`.
 - Images are fetched/decoded at startup; rows whose images can't be fetched/decoded (or that render empty text) are dropped, with a logged count.

--- a/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_completion_loss.yaml
+++ b/recipes/training/sft_vlm/qwen2_5_vl_3b_lora_completion_loss.yaml
@@ -1,0 +1,93 @@
+# Multimodal SFT with completion-only loss (split user/assistant prompts).
+#
+# Same small Qwen2.5-VL-3B smoke setup as qwen2_5_vl_3b_lora.yaml, but instead of
+# one flat training turn this recipe splits each row into a user turn and an
+# assistant turn. Loss is then computed ONLY on the assistant response (the prompt
+# is masked) -- the standard SFT recipe for instruction-tuned chat models.
+#
+# The switch is data.user_prompt + data.assistant_prompt below. Set BOTH to enable
+# split mode; omit both to fall back to the flat system_prompt template.
+model:
+  base_model_name: "Qwen/Qwen2.5-VL-3B-Instruct"
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_4bit: false
+  use_flash_attention: false
+
+  freeze_vision_tower: true
+
+  use_lora: true
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    - name: "data/sft_vlm/example_training_image_url.csv"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
+
+  image_cache_dir: "data/vlm_image_cache"
+  image_fetch_timeout: 15
+  image_fetch_retries: 3
+  max_image_pixels: 262144
+
+  image_s3_region: null
+  image_s3_endpoint_url: null
+
+  # Split (chat) mode. system_prompt is a real system-role turn; user_prompt and
+  # assistant_prompt are str.format() templates keyed by dataset_columns. Because
+  # loss is completion-only, the assistant_prompt is the only text the model is
+  # trained to produce -- keep the target (here {response}) in it, and keep inputs
+  # (the {question}) in user_prompt.
+  system_prompt: "You are a helpful multimodal assistant. Answer the user's question based on the image."
+  user_prompt: "{question}"
+  assistant_prompt: "{response}"
+
+training:
+  algorithm: "sft_vlm"
+  output_dir: "models/qwen2.5-vl-3b-sft-lora-completion-loss"
+
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 2
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: 2                 # smoke test: a couple of steps is enough
+  warmup_steps: 0
+
+  logging_steps: 1
+  save_steps: 2
+  eval_steps: 2
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true
+
+  dataloader_num_workers: 0
+  dataloader_pin_memory: false
+  dataloader_drop_last: false
+
+wandb:
+  enabled: false
+  project: "your-project"
+  entity: "your-wandb-entity"
+  name: "Qwen2.5-VL-3B-Inst-LoRA-SFT-completion-loss"
+  tags: ["SFT", "sft_vlm", "qwen2.5-vl", "3B", "LoRA", "completion-only-loss"]
+  api_key: null
+  base_url: "https://api.wandb.ai"
+
+s3:
+  enabled: false
+  bucket: "your-s3-bucket"
+  prefix: "checkpoints/qwen2.5-vl-3b-sft-lora-completion-loss"
+  region: null
+  endpoint_url: null
+  upload_checkpoints: true
+  upload_final_model: true
+  delete_local_after_upload: false

--- a/trainers/sft_trainer.py
+++ b/trainers/sft_trainer.py
@@ -50,6 +50,24 @@ class SFTTrainer(BaseTrainer):
 
         self.logger.info("Model and tokenizer loaded successfully")
 
+    def _render(self, template: str, fmt: dict) -> str:
+        """Render a str.format() template keyed by dataset columns.
+
+        Falls back to the literal template (once-warned) if it references an
+        unknown key or is malformed, mirroring the flat-mode behavior.
+        """
+        try:
+            return template.format(**fmt)
+        except (KeyError, IndexError, ValueError) as e:
+            if not getattr(self, "_tmpl_warn_emitted", False):
+                self.logger.warning(
+                    f"Prompt template not rendered ({e}); using literal text. "
+                    f"Available placeholders: {sorted(fmt)}. Double any literal "
+                    f"braces as {{{{ }}}}."
+                )
+                self._tmpl_warn_emitted = True
+            return template
+
     def setup_data(self):
         """Load and prepare training datasets."""
         datasets = []
@@ -66,37 +84,62 @@ class SFTTrainer(BaseTrainer):
 
             # Get system prompt from config
             system_prompt = self.config.data.system_prompt
-            
+
             # Get dataset columns from config
             dataset_columns = getattr(dataset_info, "dataset_columns", None)
-            
-            # Standardize column names for SFT
-            if system_prompt and dataset_columns:
-                # Use system prompt as a template with dataset columns
-                def format_with_system_prompt(example):
-                    # Create a dictionary of placeholders from dataset columns
-                    format_dict = {}
-                    for col in dataset_columns:
-                        if col in example:
-                            format_dict[col] = example[col]
-                    
-                    # Format the system prompt with the values from the dataset
-                    try:
-                        text = system_prompt.format(**format_dict)
-                    except KeyError as e:
-                        self.logger.warning(f"Missing key in system prompt template: {e}")
-                        text = system_prompt
-                    
-                    return {"text": text}
-                
-                dataset = dataset.map(format_with_system_prompt, remove_columns=dataset.column_names)
-            
-            # Filter out invalid rows where text is None or empty
-            def is_valid_example(example):
-                """Check if example has valid text field."""
-                text = example.get("text")
-                return text is not None and isinstance(text, str) and text.strip() != ""
-            
+
+            if self.config.data.split_mode:
+                # Split (chat) mode: build a conversational prompt/completion pair
+                # per row so TRL masks the prompt and computes loss only on the
+                # assistant completion (completion_only_loss). system_prompt, when
+                # set, is a real system-role turn.
+                user_tmpl = self.config.data.user_prompt
+                assistant_tmpl = self.config.data.assistant_prompt
+
+                def build_chat_example(example):
+                    fmt = {c: example.get(c, "") for c in (dataset_columns or [])}
+                    prompt = []
+                    if system_prompt:
+                        prompt.append({"role": "system", "content": self._render(system_prompt, fmt)})
+                    prompt.append({"role": "user", "content": self._render(user_tmpl, fmt)})
+                    completion = [{"role": "assistant", "content": self._render(assistant_tmpl, fmt)}]
+                    return {"prompt": prompt, "completion": completion}
+
+                dataset = dataset.map(build_chat_example, remove_columns=dataset.column_names)
+
+                def is_valid_example(example):
+                    """Require non-empty user and assistant content."""
+                    user = example["prompt"][-1]["content"]
+                    assistant = example["completion"][0]["content"]
+                    return bool(user and user.strip()) and bool(assistant and assistant.strip())
+            else:
+                # Legacy flat mode: one training turn, loss over the whole sequence.
+                if system_prompt and dataset_columns:
+                    # Use system prompt as a template with dataset columns
+                    def format_with_system_prompt(example):
+                        # Create a dictionary of placeholders from dataset columns
+                        format_dict = {}
+                        for col in dataset_columns:
+                            if col in example:
+                                format_dict[col] = example[col]
+
+                        # Format the system prompt with the values from the dataset
+                        try:
+                            text = system_prompt.format(**format_dict)
+                        except KeyError as e:
+                            self.logger.warning(f"Missing key in system prompt template: {e}")
+                            text = system_prompt
+
+                        return {"text": text}
+
+                    dataset = dataset.map(format_with_system_prompt, remove_columns=dataset.column_names)
+
+                # Filter out invalid rows where text is None or empty
+                def is_valid_example(example):
+                    """Check if example has valid text field."""
+                    text = example.get("text")
+                    return text is not None and isinstance(text, str) and text.strip() != ""
+
             dataset = dataset.filter(is_valid_example)
             
             skipped = original_size - len(dataset)
@@ -158,6 +201,10 @@ class SFTTrainer(BaseTrainer):
             ddp_find_unused_parameters=self.config.training.ddp_find_unused_parameters,
             max_length=self.config.data.max_length,
             dataset_num_proc=self.config.data.dataset_num_proc,
+            # In split mode rows are prompt/completion pairs; mask the prompt so
+            # loss is computed only on the assistant completion. (Flat mode leaves
+            # this at TRL's default of False -> loss over the whole sequence.)
+            completion_only_loss=True if self.config.data.split_mode else None,
         )
 
     def setup_trainer(self):

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -32,12 +32,19 @@ class SFTVLMTrainer(BaseTrainer):
     `system_prompt` template, and delegates to TRL's SFTTrainer. Because the
     processing class is a `ProcessorMixin`, TRL treats this as a VLM run: it skips
     its own tokenization/preprocessing and auto-selects
-    `DataCollatorForVisionLanguageModeling`, which reads each row's `messages` +
+    `DataCollatorForVisionLanguageModeling`, which reads each row's messages +
     `images` and builds `pixel_values`/`labels` on the fly.
 
+    Two data shapes are emitted depending on config. Flat mode (default) yields a
+    single-turn `messages` row and computes loss over the whole sequence. Split
+    (chat) mode -- enabled when `data.user_prompt` and `data.assistant_prompt` are
+    set -- yields a conversational `prompt`/`completion` pair so the collator masks
+    the prompt and computes loss only on the assistant completion
+    (completion_only_loss).
+
     Dataset rows are produced lazily via `Dataset.with_transform`, so images are
-    decoded to PIL only at access time and the heterogeneous multimodal
-    `messages` structure is never serialized to Arrow.
+    decoded to PIL only at access time and the heterogeneous multimodal message
+    structure is never serialized to Arrow.
     """
 
     # Load the base model as an image-text-to-text model instead of a causal LM.
@@ -49,6 +56,10 @@ class SFTVLMTrainer(BaseTrainer):
         self.model = None
         self.processor = None
         self.train_dataset = None
+        # Split (chat) mode: emit conversational prompt/completion rows and mask
+        # the prompt (completion_only_loss). Legacy flat mode emits a single
+        # `messages` turn with loss over the whole sequence.
+        self._split_mode = config.data.split_mode
 
     # ----------------------------- model -----------------------------------
 
@@ -147,13 +158,17 @@ class SFTVLMTrainer(BaseTrainer):
         and serialized safely):
           _image_sources : list[str]  -- image sources gathered, in order, from
                                           every image_columns column for the row
-          _text          : str        -- the full text built from dataset_columns
-                                          (via the system_prompt template, or by
-                                          concatenation when no template is set)
+          _text          : str        -- (flat mode) the full text built from
+                                          dataset_columns via the system_prompt
+                                          template, or concatenation when unset
+          _user_text     : str        -- (split mode) rendered user turn
+          _assistant_text: str        -- (split mode) rendered assistant turn
         """
         image_columns = dataset_info.image_columns or []
         dataset_columns = dataset_info.dataset_columns or []
         system_prompt = self.config.data.system_prompt
+        user_prompt = self.config.data.user_prompt
+        assistant_prompt = self.config.data.assistant_prompt
 
         def fn(example):
             # Gather image sources across every configured image column. Each
@@ -169,6 +184,15 @@ class SFTVLMTrainer(BaseTrainer):
                     if coerced is not None:
                         sources.append(coerced)
 
+            if self._split_mode:
+                return {
+                    "_image_sources": sources,
+                    # Empty when no system_prompt is configured; the transform then
+                    # omits the system turn entirely.
+                    "_system_text": self._build_text(system_prompt, dataset_columns, example) if system_prompt else "",
+                    "_user_text": self._build_text(user_prompt, dataset_columns, example),
+                    "_assistant_text": self._build_text(assistant_prompt, dataset_columns, example),
+                }
             return {
                 "_image_sources": sources,
                 "_text": self._build_text(system_prompt, dataset_columns, example),
@@ -209,17 +233,16 @@ class SFTVLMTrainer(BaseTrainer):
         return img.resize(new_size)
 
     def _build_text(self, template: Optional[str], dataset_columns: List[str], example) -> str:
-        """Build one text block for a row from its configured text columns.
+        """Render one text block for a row from a template + its text columns.
 
-        Mirrors the text SFT trainer: when ``system_prompt`` is set it is a
-        ``str.format`` template keyed by the dataset's column names -- a column
-        name is just a variable, so ``dataset_columns: [question, response]``
-        renders ``"...{question}...{response}"`` (double any literal braces as
-        ``{{`` / ``}}``). When no template is set, the column values are
-        concatenated in order. The whole text becomes a single training turn with
-        no prompt/completion masking, so include only what the model should learn
-        to produce. Falls back to the literal template if it references an unknown
-        key or is malformed.
+        ``template`` is a ``str.format`` template keyed by the dataset's column
+        names -- a column name is just a variable, so ``dataset_columns:
+        [question, response]`` renders ``"...{question}...{response}"`` (double any
+        literal braces as ``{{`` / ``}}``). When ``template`` is falsy, the column
+        values are concatenated in order. Used for the flat ``system_prompt``
+        template as well as the split-mode ``user_prompt`` / ``assistant_prompt``
+        / system turns. Falls back to the literal template if it references an
+        unknown key or is malformed.
         """
         fmt = {col: example.get(col, "") for col in dataset_columns}
         if template:
@@ -238,6 +261,9 @@ class SFTVLMTrainer(BaseTrainer):
 
     def _make_transform(self):
         """Build the lazy with_transform callable (batched columnar input)."""
+        if self._split_mode:
+            return self._make_split_transform()
+
         def transform(batch):
             out_messages, out_images = [], []
             for text, sources in zip(batch["_text"], batch["_image_sources"]):
@@ -250,6 +276,34 @@ class SFTVLMTrainer(BaseTrainer):
                 out_messages.append(messages)
                 out_images.append(images)
             return {"messages": out_messages, "images": out_images}
+
+        return transform
+
+    def _make_split_transform(self):
+        """Lazy transform for split (chat) mode: conversational prompt/completion.
+
+        Emits `prompt` (optional system turn + user turn) and `completion` (the
+        assistant turn) so TRL's vision collator takes its prompt/completion path
+        and masks the prompt (completion_only_loss). Images attach to the user turn
+        -- the collator inserts one image placeholder per image via
+        `prepare_multimodal_messages`.
+        """
+        def transform(batch):
+            out_prompt, out_completion, out_images = [], [], []
+            for sys_text, user_text, assistant_text, sources in zip(
+                batch["_system_text"], batch["_user_text"],
+                batch["_assistant_text"], batch["_image_sources"],
+            ):
+                images = self._fetch_images(sources)
+                prompt = []
+                if sys_text:
+                    prompt.append({"role": "system", "content": sys_text})
+                prompt.append({"role": "user", "content": user_text})
+                completion = [{"role": "assistant", "content": assistant_text}]
+                out_prompt.append(prompt)
+                out_completion.append(completion)
+                out_images.append(images)
+            return {"prompt": out_prompt, "completion": out_completion, "images": out_images}
 
         return transform
 
@@ -274,7 +328,10 @@ class SFTVLMTrainer(BaseTrainer):
             def is_valid(example):
                 if not example["_image_sources"]:
                     return False
-                if not example["_text"].strip():
+                if self._split_mode:
+                    if not example["_user_text"].strip() or not example["_assistant_text"].strip():
+                        return False
+                elif not example["_text"].strip():
                     return False
                 try:
                     self._fetch_images(example["_image_sources"])
@@ -346,6 +403,10 @@ class SFTVLMTrainer(BaseTrainer):
             # be cut, which crashes the processor / model.
             max_length=None,
             dataset_num_proc=self.config.data.dataset_num_proc,
+            # Split mode emits prompt/completion rows; mask the prompt so the
+            # vision collator computes loss only on the assistant completion. Flat
+            # mode leaves this False (loss over the whole sequence).
+            completion_only_loss=True if self._split_mode else None,
         )
 
     def setup_trainer(self):

--- a/utils/debug_callback.py
+++ b/utils/debug_callback.py
@@ -1,0 +1,436 @@
+"""DebugCallback: verbose, observation-only training instrumentation.
+
+Always attached by BaseTrainer.build_callbacks(). Every hook is wrapped so a
+logging failure can never crash training -- output is strictly best-effort.
+Records emit at INFO level so they always print (subject to the usual rank-0
+filter; set FAI_RL_LOG_ALL_RANKS=1 to see every rank). Per-step lines are
+throttled (first FAI_RL_DEBUG_STEPS steps, then every logging_steps) to avoid
+flooding long runs.
+
+What it logs:
+  - Config & arch: model class, dtype, attention impl, total/trainable params,
+    PEFT adapters, tokenizer/processor id, special tokens, chat template.
+  - First batches decoded: input_ids -> text, labels showing masked (-100) vs
+    supervised tokens, attention mask, per-example sequence lengths, truncation.
+  - Tokenization sanity: round-trip decode, BOS/EOS presence, padding side.
+  - Loss/masking stats: % tokens masked per batch, best-effort per-example loss.
+  - Optimizer/scheduler: LR at step 0, param groups, grad norm (pre-clip).
+  - Distributed: world size / rank, per-rank batch fingerprint (data duplication).
+  - Memory/perf: peak accelerator memory, approx tokens/sec, step time.
+  - Progress: step count, checkpoint saves.
+"""
+
+import os
+import time
+from typing import Any, Optional
+
+from transformers import TrainerCallback
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _rank() -> int:
+    for key in ("RANK", "LOCAL_RANK"):
+        v = os.environ.get(key)
+        if v:
+            try:
+                return int(v)
+            except ValueError:
+                pass
+    return 0
+
+
+def _world_size() -> int:
+    return _env_int("WORLD_SIZE", 1)
+
+
+def _short(text: str, limit: int = 800) -> str:
+    """Truncate long text for logging with an elision marker."""
+    text = text.replace("\n", "\\n")
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]} ... [+{len(text) - limit} chars]"
+
+
+class DebugCallback(TrainerCallback):
+    """Verbose, non-intrusive debug logging for HF/TRL Trainer runs."""
+
+    def __init__(self, logger, config=None):
+        # `logger` may be a SafeLogger wrapper or a stdlib Logger; both expose
+        # .debug/.info/.warning.
+        self.log = logger
+        self.config = config
+        # Log full per-step detail for the first N steps, then throttle to every
+        # logging_steps to avoid flooding long runs.
+        self.max_verbose_steps = _env_int("FAI_RL_DEBUG_STEPS", 5)
+        self.num_first_batches = _env_int("FAI_RL_DEBUG_BATCHES", 1)
+        self._last_step_time: Optional[float] = None
+        self._approx_tokens_per_step: Optional[int] = None
+        self._logging_steps = 10
+
+    # ------------------------------------------------------------------ utils
+    def _d(self, msg: str) -> None:
+        """Rank-prefixed diagnostic line at INFO (best-effort, never raises)."""
+        try:
+            self.log.info(f"[diag r{_rank()}] {msg}")
+        except Exception:
+            pass
+
+    @staticmethod
+    def _get_tokenizer(processing_class):
+        """Return a tokenizer from either a bare tokenizer or a VLM processor."""
+        return getattr(processing_class, "tokenizer", processing_class)
+
+    # ---------------------------------------------------------- train begin
+    def on_train_begin(self, args, state, control, **kwargs):
+        self._logging_steps = getattr(args, "logging_steps", 10) or 10
+        model = kwargs.get("model")
+        processing_class = kwargs.get("processing_class")
+        optimizer = kwargs.get("optimizer")
+        lr_scheduler = kwargs.get("lr_scheduler")
+        train_dataloader = kwargs.get("train_dataloader")
+
+        self._d("=" * 60)
+        self._d("Training diagnostics (observation-only instrumentation)")
+        self._d("=" * 60)
+
+        self._log_distributed(args)
+        self._log_arch(model)
+        self._log_tokenizer(processing_class)
+        self._log_optimizer(optimizer, lr_scheduler)
+        self._log_first_batches(train_dataloader, processing_class, model, args)
+
+    def _log_distributed(self, args):
+        try:
+            self._d(
+                f"Distributed: world_size={_world_size()} rank={_rank()} "
+                f"local_rank={os.environ.get('LOCAL_RANK', '0')} "
+                f"n_gpu={getattr(args, 'n_gpu', '?')} "
+                f"parallel_mode={getattr(args, 'parallel_mode', '?')}"
+            )
+            ds = getattr(args, "deepspeed", None)
+            self._d(f"DeepSpeed config: {ds if ds else 'none (DDP/single)'}")
+            self._d(
+                f"Effective batch: per_device={getattr(args, 'per_device_train_batch_size', '?')} "
+                f"x grad_accum={getattr(args, 'gradient_accumulation_steps', '?')} "
+                f"x world={_world_size()} = "
+                f"{getattr(args, 'per_device_train_batch_size', 0) * getattr(args, 'gradient_accumulation_steps', 0) * _world_size()}"
+            )
+        except Exception as e:
+            self._d(f"(distributed info failed: {e})")
+
+    def _log_arch(self, model):
+        if model is None:
+            self._d("Model not available at on_train_begin")
+            return
+        try:
+            self._d(f"Model class: {model.__class__.__name__}")
+            cfg = getattr(model, "config", None)
+            if cfg is not None:
+                self._d(
+                    f"Arch: model_type={getattr(cfg, 'model_type', '?')} "
+                    f"attn_impl={getattr(cfg, '_attn_implementation', '?')} "
+                    f"torch_dtype={getattr(cfg, 'torch_dtype', '?')} "
+                    f"vocab_size={getattr(cfg, 'vocab_size', '?')}"
+                )
+            # Parameter dtype histogram (what the weights actually are at runtime).
+            dtypes = {}
+            for p in model.parameters():
+                dtypes[str(p.dtype)] = dtypes.get(str(p.dtype), 0) + p.numel()
+            self._d("Param dtypes: " + ", ".join(f"{k}={v:,}" for k, v in dtypes.items()))
+
+            total = sum(p.numel() for p in model.parameters())
+            trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+            pct = (100.0 * trainable / total) if total else 0.0
+            self._d(f"Params: total={total:,} trainable={trainable:,} ({pct:.4f}%)")
+
+            # PEFT adapter summary, if any.
+            if hasattr(model, "peft_config"):
+                for name, pc in model.peft_config.items():
+                    self._d(
+                        f"PEFT adapter '{name}': type={getattr(pc, 'peft_type', '?')} "
+                        f"r={getattr(pc, 'r', '?')} alpha={getattr(pc, 'lora_alpha', '?')} "
+                        f"targets={getattr(pc, 'target_modules', '?')}"
+                    )
+        except Exception as e:
+            self._d(f"(arch info failed: {e})")
+
+    def _log_tokenizer(self, processing_class):
+        if processing_class is None:
+            self._d("Processing class not available")
+            return
+        try:
+            tok = self._get_tokenizer(processing_class)
+            self._d(f"Processing class: {processing_class.__class__.__name__}")
+            self._d(f"Tokenizer: {tok.__class__.__name__} vocab_size={getattr(tok, 'vocab_size', '?')}")
+            self._d(
+                f"Special tokens: bos={getattr(tok, 'bos_token', None)!r}({getattr(tok, 'bos_token_id', None)}) "
+                f"eos={getattr(tok, 'eos_token', None)!r}({getattr(tok, 'eos_token_id', None)}) "
+                f"pad={getattr(tok, 'pad_token', None)!r}({getattr(tok, 'pad_token_id', None)}) "
+                f"padding_side={getattr(tok, 'padding_side', '?')}"
+            )
+            ct = getattr(tok, "chat_template", None)
+            if ct:
+                self._d(f"Chat template present ({len(ct)} chars): {_short(ct, 300)}")
+            else:
+                self._d("Chat template: none")
+        except Exception as e:
+            self._d(f"(tokenizer info failed: {e})")
+
+    def _log_optimizer(self, optimizer, lr_scheduler):
+        try:
+            if optimizer is not None:
+                self._d(f"Optimizer: {optimizer.__class__.__name__} "
+                        f"({len(optimizer.param_groups)} param groups)")
+                for i, g in enumerate(optimizer.param_groups):
+                    n_params = sum(p.numel() for p in g.get("params", []))
+                    self._d(
+                        f"  group[{i}]: lr={g.get('lr')} weight_decay={g.get('weight_decay')} "
+                        f"n_tensors={len(g.get('params', []))} n_params={n_params:,}"
+                    )
+            if lr_scheduler is not None:
+                self._d(f"LR scheduler: {lr_scheduler.__class__.__name__}")
+                try:
+                    self._d(f"LR at step 0: {lr_scheduler.get_last_lr()}")
+                except Exception:
+                    pass
+        except Exception as e:
+            self._d(f"(optimizer info failed: {e})")
+
+    # ------------------------------------------------------- first batches
+    def _log_first_batches(self, train_dataloader, processing_class, model, args):
+        if train_dataloader is None:
+            self._d("train_dataloader not available; skipping batch inspection")
+            return
+        tok = self._get_tokenizer(processing_class)
+        try:
+            it = iter(train_dataloader)
+        except Exception as e:
+            self._d(f"(could not iterate train_dataloader: {e})")
+            return
+
+        for b in range(self.num_first_batches):
+            try:
+                batch = next(it)
+            except StopIteration:
+                break
+            except Exception as e:
+                self._d(f"(fetching batch {b} failed: {e})")
+                break
+            self._d(f"----- first batch #{b} -----")
+            self._inspect_batch(batch, tok, args)
+            self._maybe_per_example_loss(batch, model)
+
+    def _inspect_batch(self, batch, tok, args):
+        try:
+            if not isinstance(batch, dict):
+                self._d(f"Batch type {type(batch)} (not a dict); keys unavailable")
+                return
+            self._d("Batch keys: " + ", ".join(f"{k}:{tuple(getattr(v, 'shape', ()))}"
+                                                for k, v in batch.items()))
+            input_ids = batch.get("input_ids")
+            attention_mask = batch.get("attention_mask")
+            labels = batch.get("labels")
+
+            # Multimodal signal
+            if "pixel_values" in batch:
+                pv = batch["pixel_values"]
+                self._d(f"pixel_values present: shape={tuple(getattr(pv, 'shape', ()))} dtype={getattr(pv, 'dtype', '?')}")
+
+            if input_ids is None:
+                self._d("No input_ids in batch")
+                return
+
+            # Sequence-length stats + truncation.
+            if attention_mask is not None:
+                lengths = attention_mask.sum(dim=1).tolist()
+            else:
+                lengths = [input_ids.shape[1]] * input_ids.shape[0]
+            self._d(f"Seq lengths (real tokens): {lengths} | padded_to={input_ids.shape[1]}")
+            # Rough tokens/step estimate for the tok/s readout in on_step_end:
+            # one micro-batch's real tokens x grad_accum x world_size.
+            if self._approx_tokens_per_step is None:
+                ga = getattr(args, "gradient_accumulation_steps", 1) or 1
+                self._approx_tokens_per_step = int(sum(lengths)) * ga * _world_size()
+            max_len = getattr(args, "max_length", None)
+            if max_len:
+                n_trunc = sum(1 for L in lengths if L >= max_len)
+                if n_trunc:
+                    self._d(f"WARNING: {n_trunc}/{len(lengths)} examples at/over max_length={max_len} (possible truncation)")
+
+            # Per-rank fingerprint to catch data duplication across ranks.
+            try:
+                fp = int(input_ids[0].sum().item())
+                self._d(f"Data fingerprint (row0 input_ids sum): {fp} "
+                        f"first8={input_ids[0][:8].tolist()} "
+                        f"(compare across ranks with FAI_RL_LOG_ALL_RANKS=1)")
+            except Exception:
+                pass
+
+            # Decode + round-trip sanity on example 0.
+            ids0 = input_ids[0].tolist()
+            decoded = tok.decode(ids0, skip_special_tokens=False)
+            self._d(f"Decoded input[0] (with specials): {_short(decoded)}")
+            self._d(f"BOS present: {tok.bos_token_id in ids0 if tok.bos_token_id is not None else 'n/a'} | "
+                    f"EOS present: {tok.eos_token_id in ids0 if tok.eos_token_id is not None else 'n/a'}")
+            try:
+                reencoded = tok(decoded, add_special_tokens=False)["input_ids"]
+                self._d(f"Round-trip decode: len_in={len(ids0)} len_reencoded={len(reencoded)} "
+                        f"exact_match={reencoded == ids0}")
+            except Exception:
+                pass
+
+            # Masking: masked (-100) vs supervised, aligned with tokens.
+            if labels is not None:
+                self._log_masking(input_ids, labels, tok)
+        except Exception as e:
+            self._d(f"(batch inspection failed: {e})")
+
+    def _log_masking(self, input_ids, labels, tok):
+        try:
+            total = labels.numel()
+            masked = int((labels == -100).sum().item())
+            supervised = total - masked
+            self._d(f"Label masking: {masked:,}/{total:,} masked (-100) = "
+                    f"{100.0 * masked / total:.1f}% | supervised={supervised:,} "
+                    f"({100.0 * supervised / total:.1f}%)")
+            # Show supervised span for example 0.
+            lab0 = labels[0]
+            sup_ids = input_ids[0][lab0 != -100].tolist()
+            if sup_ids:
+                self._d(f"Supervised region (labels != -100) of example[0] decodes to: "
+                        f"{_short(tok.decode(sup_ids, skip_special_tokens=False))}")
+            else:
+                self._d("Example[0] has NO supervised tokens (all labels == -100!)")
+            # Compact aligned view of the boundary (first 40 positions).
+            ids0 = input_ids[0][:40].tolist()
+            l0 = lab0[:40].tolist()
+            preview = " ".join(
+                f"{tok.convert_ids_to_tokens([t])[0]}{'*' if lv == -100 else ''}"
+                for t, lv in zip(ids0, l0)
+            )
+            self._d(f"Token/label align (first 40, * = masked): {_short(preview)}")
+        except Exception as e:
+            self._d(f"(masking stats failed: {e})")
+
+    def _maybe_per_example_loss(self, batch, model):
+        """Best-effort per-example loss via one no-grad forward. Skipped on any
+        error (e.g. OOM on very large models / long sequences)."""
+        if model is None or not isinstance(batch, dict) or "labels" not in batch:
+            return
+        try:
+            import torch
+
+            device = next(model.parameters()).device
+            model_inputs = {}
+            for k, v in batch.items():
+                model_inputs[k] = v.to(device) if hasattr(v, "to") else v
+            labels = model_inputs["labels"]
+            was_training = model.training
+            model.eval()
+            with torch.no_grad():
+                out = model(**model_inputs)
+            if was_training:
+                model.train()
+            logits = out.logits.float()
+            # Causal shift.
+            shift_logits = logits[:, :-1, :]
+            shift_labels = labels[:, 1:]
+            loss_tok = torch.nn.functional.cross_entropy(
+                shift_logits.reshape(-1, shift_logits.size(-1)),
+                shift_labels.reshape(-1),
+                ignore_index=-100,
+                reduction="none",
+            ).view(shift_labels.size())
+            valid = (shift_labels != -100)
+            per_ex = (loss_tok * valid).sum(dim=1) / valid.sum(dim=1).clamp(min=1)
+            self._d(f"Per-example loss (batch 0, no-grad): "
+                    f"{[round(x, 4) for x in per_ex.tolist()]} | mean={per_ex.mean().item():.4f}")
+        except Exception as e:
+            self._d(f"(per-example loss skipped: {type(e).__name__}: {e})")
+
+    # ----------------------------------------------------------- per step
+    def _should_verbose(self, step: int) -> bool:
+        return step <= self.max_verbose_steps or (step % self._logging_steps == 0)
+
+    def on_pre_optimizer_step(self, args, state, control, **kwargs):
+        """Grad norm BEFORE clipping (post-clip shows up in on_log as grad_norm)."""
+        step = int(getattr(state, "global_step", 0)) + 1
+        if not self._should_verbose(step):
+            return
+        model = kwargs.get("model")
+        if model is None:
+            return
+        try:
+            import torch
+
+            total_sq = 0.0
+            n = 0
+            for p in model.parameters():
+                if p.grad is not None:
+                    total_sq += float(p.grad.detach().data.norm(2).item()) ** 2
+                    n += 1
+            self._d(f"[step {step}] grad norm (pre-clip) over {n} tensors: {total_sq ** 0.5:.4f} "
+                    f"(max_grad_norm={getattr(args, 'max_grad_norm', '?')})")
+        except Exception as e:
+            self._d(f"(grad norm failed: {e})")
+
+    def on_step_end(self, args, state, control, **kwargs):
+        step = int(getattr(state, "global_step", 0))
+        now = time.time()
+        dt = None if self._last_step_time is None else now - self._last_step_time
+        self._last_step_time = now
+        if not self._should_verbose(step):
+            return
+        try:
+            parts = [f"[step {step}]"]
+            if dt is not None:
+                parts.append(f"step_time={dt:.3f}s")
+                if self._approx_tokens_per_step:
+                    parts.append(f"~{self._approx_tokens_per_step / dt:,.0f} tok/s (approx)")
+            parts.append(self._mem_str())
+            self._d(" ".join(parts))
+        except Exception as e:
+            self._d(f"(step_end stats failed: {e})")
+
+    @staticmethod
+    def _mem_str() -> str:
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                alloc = torch.cuda.memory_allocated() / 1024**3
+                peak = torch.cuda.max_memory_allocated() / 1024**3
+                reserved = torch.cuda.memory_reserved() / 1024**3
+                torch.cuda.reset_peak_memory_stats()
+                return f"mem alloc={alloc:.2f}GB peak={peak:.2f}GB reserved={reserved:.2f}GB"
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                return f"mps alloc={torch.mps.current_allocated_memory() / 1024**3:.2f}GB"
+        except Exception:
+            pass
+        return "mem n/a (cpu)"
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        """Echo the trainer's own metrics (loss, grad_norm, lr) at debug level."""
+        if not logs:
+            return
+        try:
+            keep = {k: logs[k] for k in ("loss", "grad_norm", "learning_rate", "epoch") if k in logs}
+            if keep:
+                self._d(f"[step {int(getattr(state, 'global_step', 0))}] metrics: {keep}")
+        except Exception:
+            pass
+
+    def on_save(self, args, state, control, **kwargs):
+        try:
+            step = int(getattr(state, "global_step", 0))
+            ckpt = os.path.join(getattr(args, "output_dir", "?"), f"checkpoint-{step}")
+            self._d(f"[step {step}] checkpoint saved -> {ckpt} "
+                    f"(save_only_model={getattr(args, 'save_only_model', '?')})")
+        except Exception:
+            pass


### PR DESCRIPTION
Add an optional split (chat) mode to both SFT trainers so loss is computed only on the assistant response instead of the whole flat sequence.

Setting both data.user_prompt and data.assistant_prompt (str.format templates keyed by dataset_columns, like system_prompt) emits conversational prompt/completion rows and enables completion_only_loss; system_prompt becomes a real system-role turn. Omitting both keeps the legacy flat single-turn behavior, so all existing recipes are unaffected.

Both trainers use prompt/completion + completion_only_loss rather than assistant_only_loss, since TRL's DataCollatorForVisionLanguageModeling only supports the former; this keeps text and VLM paths uniform and needs no chat-template {% generation %} support.

- core/config.py: user_prompt/assistant_prompt fields, split_mode property, both-or-neither validation, to_dict wiring
- trainers/sft_trainer.py: emit prompt/completion in split mode, _render helper
- trainers/sft_vlm_trainer.py: split-mode normalize + transform, validation
- recipes/training/sft_vlm/qwen2_5_vl_3b_lora_completion_loss.yaml: example
- recipes/training/README.md: document the new keys