### PR TITLE
Gemma-4-31B recipes + VLM LoRA vision-tower exclusion, single-GPU DataParallel fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ FAI-RL provides a unified, extensible framework for fine-tuning language models 
   - [Inference](#inference)
   - [Evaluation](#evaluation)
 - [Supported Methods](#supported-methods)
+- [Supported Models](#supported-models)
 - [Key Features](#key-features)
 - [Project Structure](#-project-structure)
 - [S3 Checkpoint Upload](#-s3-checkpoint-upload)
@@ -196,6 +197,22 @@ Additional features supported across all algorithms:
 - ✅ Custom reward functions and dataset templates
 - ✅ Weights & Biases integration for experiment tracking
 - ✅ Automatic S3 checkpoint upload (supports S3-compatible stores)
+
+## Supported Models
+
+FAI-RL provides pre-configured recipes and has been validated with the following models:
+
+| # | Model |
+|---|-------|
+| 1 | Qwen3 30B A3B Instruct (2507) |
+| 2 | Qwen3.6 27B |
+| 3 | Gemma 4 31B |
+| 4 | Gemma 4 26B A4B IT |
+| 5 | Qwen3-VL 30B A3B |
+| 6 | Qwen3 8B |
+| 7 | Qwen3 4B |
+| 8 | Llama 3.2 3B |
+| 9 | Llama 3.1 8B |
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,52 @@ FAI-RL provides a unified, extensible framework for fine-tuning language models 
 
 ## 📦 Installation
 
-### Install the Package
+FAI-RL does **not** pin `torch` in its package metadata, so it stays
+cross-platform and never locks you to a single CUDA build. You install a
+`torch`/`torchvision` build matching your host first, then install FAI-RL on
+top. We recommend a dedicated conda environment.
 
-We assume the user environment already has the necessary ML libraries
-installed (notably `torch`, with a CUDA build matching the host).
+### 1. Create a conda environment
 
 ```bash
-pip install FAI-RL
+conda create -n fai-rl python=3.12 -y
+conda activate fai-rl
 ```
 
-### Clone the Repository for Configuration Recipes
+> Python 3.9–3.12 are supported.
+
+### 2. Clone the repository
+
+The training/inference/evaluation commands read recipe YAMLs that live in the
+repo, so cloning is recommended even if you install from PyPI.
 
 ```bash
 git clone https://github.com/Roblox/FAI-RL.git
 cd FAI-RL
 ```
+
+### 3. Install PyTorch (CUDA 13.0)
+
+`requirements-cu130.txt` pulls `torch`/`torchvision` from the CUDA 13.0 wheel
+index. For a different CUDA version, edit the index URL in that file (e.g.
+`cu121`, `cu124`).
+
+```bash
+pip install -r requirements-cu130.txt
+```
+
+### 4. Install FAI-RL
+
+```bash
+# From source (editable) — recommended, includes the recipe YAMLs
+pip install -e ".[cuda]"        # bitsandbytes, deepspeed, mpi4py
+
+# ...or from PyPI
+pip install "FAI-RL[cuda]"
+```
+
+> The `[cuda]` extra is Linux/NVIDIA only. On macOS, omit it: `pip install -e .`
+
 
 > **Package**: [https://pypi.org/project/FAI-RL/](https://pypi.org/project/FAI-RL/)
 

--- a/core/config.py
+++ b/core/config.py
@@ -1,6 +1,6 @@
 # rl_finetuning/core/config.py
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Any, List, Literal
+from typing import Optional, Dict, Any, List, Literal, Union
 import yaml
 import sys
 import os
@@ -40,6 +40,17 @@ class ModelConfig:
     lora_alpha: int = 16
     lora_dropout: float = 0.05
     lora_target_modules: Optional[List[str]] = None
+    # Module name patterns to exclude from LoRA injection even if they match
+    # lora_target_modules. Needed for VLMs, where the (frozen) vision tower has
+    # attention projections named like the language model's (q_proj/k_proj/...)
+    # but wrapped in custom module types PEFT can't adapt. The sft_vlm trainer
+    # auto-populates this with the vision tower when freeze_vision_tower is set
+    # and no explicit list is given.
+    #
+    # A list matches leaf module names (suffix match); a single string is treated
+    # by PEFT as a regex full-matched against the whole module path, which is what
+    # you need to exclude an entire subtree such as ".*vision_tower.*".
+    lora_exclude_modules: Optional[Union[str, List[str]]] = None
     lora_bias: str = "none"
 
     # Multimodal (vision-language) configuration. Only used by the sft_vlm
@@ -67,6 +78,7 @@ class ModelConfig:
             "lora_alpha": self.lora_alpha,
             "lora_dropout": self.lora_dropout,
             "lora_target_modules": self.lora_target_modules,
+            "lora_exclude_modules": self.lora_exclude_modules,
             "lora_bias": self.lora_bias,
             "freeze_vision_tower": self.freeze_vision_tower,
         }

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -696,7 +696,7 @@ class BaseTrainer(ABC):
                 pass
         
         # Create LoRA config
-        lora_config = LoraConfig(
+        lora_kwargs = dict(
             r=self.config.model.lora_r,
             lora_alpha=self.config.model.lora_alpha,
             lora_dropout=self.config.model.lora_dropout,
@@ -704,6 +704,15 @@ class BaseTrainer(ABC):
             bias=self.config.model.lora_bias,
             task_type=task_type,
         )
+        # exclude_modules keeps target-module name matching (e.g. q_proj) from
+        # leaking into submodules we must not adapt -- notably a VLM's frozen
+        # vision tower, whose attention projections share those names but are
+        # custom module types PEFT cannot wrap. Only pass it when set so we stay
+        # compatible with peft versions lacking the field.
+        exclude_modules = getattr(self.config.model, "lora_exclude_modules", None)
+        if exclude_modules:
+            lora_kwargs["exclude_modules"] = exclude_modules
+        lora_config = LoraConfig(**lora_kwargs)
         
         # Apply LoRA to model
         model = get_peft_model(model, lora_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.1.42"
+version = "0.1.43"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
     "tiktoken==0.12.0",
     "boto3==1.42.92",
     "pillow==11.3.0",
-    "requests==2.32.5"
+    "requests==2.32.5",
+    "torchvision==0.28.0"
 ]
 
 [project.optional-dependencies]

--- a/recipes/inference/gemma_4_31b_it.yaml
+++ b/recipes/inference/gemma_4_31b_it.yaml
@@ -1,0 +1,55 @@
+# Inference for a fine-tuned Gemma-4-31B-it (multimodal, dense) checkpoint.
+#
+# Setting `image_columns` enables VLM mode: each row's image URL/path is fetched
+# into a PIL image and fed to the model alongside the templated text prompt.
+# Use this after training with recipes/training/sft_vlm/gemma_4_31b_it_lora.yaml.
+# For a recipe that feeds multiple images per row, see qwen2_5_vl_3b_multi_image.yaml.
+#
+# The 31B model is too large for one GPU; the inference engine loads it with
+# device_map="auto", which automatically shards the weights across all visible
+# GPUs. Expose the GPUs you want it to use and run from the repo root:
+#
+#   CUDA_VISIBLE_DEVICES=0,1,2,3 fai-rl-inference \
+#     --recipe recipes/inference/gemma_4_31b_it.yaml
+#   # or: python inference/inference.py --recipe recipes/inference/gemma_4_31b_it.yaml
+inference:
+  # Local fine-tuned checkpoint (LoRA adapter + processor) or a vanilla VLM hub id.
+  model_paths:
+    - "models/gemma-4-31b-it-sft-lora-v1"
+
+  output_file: "outputs/gemma-4-31b-it-sft-lora-v1-infer.csv"
+
+  # Dataset: an S3-hosted CSV with image_url + question columns (downloaded to a temp
+  # path at startup). A local CSV path or a HuggingFace dataset id with an image-URL
+  # column works too -- just point dataset_name at it. boto3 creds resolve from the
+  # environment; s3_region / s3_endpoint_url (below) override when set.
+  dataset_name: "s3://your-bucket/datasets/example_inference_data.csv"
+  s3_region: null          # AWS region override (null = use AWS_DEFAULT_REGION). Also applies to s3:// model_paths.
+  s3_endpoint_url: null     # Custom S3-compatible endpoint (null = AWS S3)
+  dataset_split: "test"
+  dataset_columns: ["image_url", "question"]
+  response_column: "response"
+
+  # Multimodal config: image_columns lists the column(s) holding the image URL/path
+  # (each cell may be a single value or a list). Its presence enables VLM inference;
+  # all images found across the listed columns are fed to the model per row.
+  image_columns: ["image_url"]
+  image_cache_dir: "data/vlm_image_cache"
+  image_fetch_timeout: 15
+  image_fetch_retries: 3
+  max_image_pixels: 1048576         # ~1MP; match what you trained with
+
+  # The prompt template is filled per row from dataset_columns and becomes the
+  # user text accompanying the image. It MUST contain at least one {placeholder}.
+  # Mirrors the sft_vlm training system_prompt; the training "Response: {response}"
+  # line becomes a bare "Response:" cue here ({response} is what the model generates).
+  system_prompt: |
+    You are a helpful multimodal assistant. Answer the user's question based on the image.
+    Question: {question}
+    Response:
+
+  # Generation parameters. Greedy decoding for reproducible captions.
+  temperature: 1.0
+  top_p: 0.9
+  max_new_tokens: 512
+  do_sample: false

--- a/recipes/training/sft_vlm/gemma_4_26b_a4b_it_lora.yaml
+++ b/recipes/training/sft_vlm/gemma_4_26b_a4b_it_lora.yaml
@@ -1,0 +1,110 @@
+# Multimodal (image + text) LoRA SFT recipe for Gemma-4-26B-A4B-it.
+#
+# Gemma-4-26B-A4B is a Mixture-of-Experts VLM (~26B total / ~4B active params).
+# Although only ~4B params are active per token, ALL expert weights must be
+# resident, so the base model (~52GB in bf16) does NOT fit replicated per-GPU.
+# This recipe trains with DeepSpeed ZeRO-3 + CPU offload to shard parameters and
+# optimizer state across GPUs. Launch it multi-GPU through the trainer so it
+# routes to the DeepSpeed launcher:
+#
+#   source activate_env.sh          # sets the CUDA 13 / GCC 12 build toolchain
+#   python trainers/train.py --num-gpus 8 \
+#     --recipe recipes/training/sft_vlm/gemma_4_26b_a4b_it_lora.yaml
+#
+# (Single-GPU is not realistic for this model; use the qwen2_5_vl_3b recipe for
+# smoke tests.) Swap in your own dataset under `data.datasets`.
+model:
+  base_model_name: "google/gemma-4-26B-A4B-it"
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_4bit: false
+  use_flash_attention: true        # falls back to SDPA automatically if flash_attn isn't installed
+
+  freeze_vision_tower: true
+
+  use_lora: true
+  lora_r: 16                       # a bit more capacity than the 3B recipe (r=8) for the larger LM
+  lora_alpha: 32                   # ~2x rank
+  lora_dropout: 0.05
+  # Attention projections only. The MoE expert MLPs (gate/up/down per expert)
+  # are intentionally left untouched -- adapting them explodes the adapter count
+  # and is not needed for standard VLM SFT. The frozen vision tower is excluded
+  # from LoRA injection automatically (its attention shares these names but is a
+  # module type PEFT can't wrap), so no manual lora_exclude_modules is needed.
+  lora_target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    # Placeholder dataset (the 5-row smoke example). Replace with your real data;
+    # the schema is one or more image_columns (URL/path/bytes) + the text columns
+    # listed in dataset_columns. List several image_columns for multi-image rows.
+    - name: "data/sft_vlm/example_training_image_url.csv"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
+
+  image_cache_dir: "data/vlm_image_cache"
+  image_fetch_timeout: 15
+  image_fetch_retries: 3
+  max_image_pixels: 1048576        # ~1MP; raise/lower to trade quality vs. memory
+
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
+  system_prompt: |
+    You are a helpful multimodal assistant. Answer the user's question based on the image.
+    Question: {question}
+    Response: {response}
+
+training:
+  algorithm: "sft_vlm"
+  output_dir: "models/gemma-4-26b-a4b-it-sft-lora-v1"
+
+  # ZeRO-3 + CPU offload shards/offloads the 26B base weights and optimizer state
+  # so LoRA SFT fits across multiple GPUs. Requires DeepSpeed to be installed.
+  deepspeed_config: "configs/deepspeed/zero3_config.json"
+
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8   # effective batch = 1 x 8 x num_gpus
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: -1                    # -1 = train for num_train_epochs
+  warmup_steps: 20
+
+  logging_steps: 5
+  save_steps: 50
+  eval_steps: 50
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true     # essential at this scale
+
+  dataloader_num_workers: 4
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+
+wandb:
+  enabled: false                                              # Enable W&B logging
+  project: "your-project"                                     # W&B project name
+  entity: "your-wandb-entity"                                 # W&B username or team name
+  name: "Gemma-4-26B-A4B-it-LoRA-SFT"                         # Experiment name in W&B
+  tags: ["SFT", "sft_vlm", "gemma-4", "26B-A4B", "MoE", "LoRA"]   # Tags for organizing experiments
+  api_key: null                                               # W&B API key (null = use WANDB_API_KEY env var or prior `wandb login`)
+  base_url: "https://api.wandb.ai"                            # W&B base URL (null = use WANDB_BASE_URL env var)
+
+# S3 Checkpoint Upload
+# Automatically uploads checkpoints and the final model to S3
+s3:
+  enabled: false                                         # Enable S3 checkpoint upload
+  bucket: "your-s3-bucket"                               # S3 bucket name
+  prefix: "checkpoints/gemma-4-26b-a4b-it-sft-lora-v1"   # S3 key prefix (folder path inside bucket)
+  region: null                                           # AWS region (null = use AWS_DEFAULT_REGION env var or boto3 default)
+  endpoint_url: null                                     # Custom S3-compatible endpoint (e.g. MinIO). null = AWS S3
+  upload_checkpoints: true                               # Upload intermediate checkpoints (at every save_steps)
+  upload_final_model: true                               # Upload the final model at end of training
+  delete_local_after_upload: false                       # Delete local checkpoint files after successful upload

--- a/recipes/training/sft_vlm/gemma_4_31b_it_lora.yaml
+++ b/recipes/training/sft_vlm/gemma_4_31b_it_lora.yaml
@@ -1,0 +1,106 @@
+# Multimodal (image + text) LoRA SFT recipe for Gemma-4-31B-it.
+#
+# Gemma-4-31B is a dense VLM (~31B params). At this scale the base weights
+# (~62GB in bf16) do NOT fit replicated per-GPU, so this recipe trains with
+# DeepSpeed ZeRO-3 + CPU offload to shard parameters and optimizer state across
+# GPUs. Launch it multi-GPU through the trainer so it routes to the DeepSpeed
+# launcher:
+#
+#   python trainers/train.py --num-gpus 8 \
+#     --recipe recipes/training/sft_vlm/gemma_4_31b_it_lora.yaml
+#
+# (Single-GPU is not realistic for this model; use the qwen2_5_vl_3b recipe for
+# smoke tests.) Swap in your own dataset under `data.datasets`.
+model:
+  base_model_name: "google/gemma-4-31B-it"
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_4bit: false
+  use_flash_attention: true        # falls back to SDPA automatically if flash_attn isn't installed
+
+  freeze_vision_tower: true
+
+  use_lora: true
+  lora_r: 16                       # a bit more capacity than the 3B recipe (r=8) for the larger LM
+  lora_alpha: 32                   # ~2x rank
+  lora_dropout: 0.05
+  # Attention projections only. Adapting the (dense) MLP blocks as well is an
+  # option for higher capacity, but the attention-only target set is the
+  # standard, memory-cheap choice for VLM SFT.
+  lora_target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    # Placeholder dataset (the 5-row smoke example). Replace with your real data;
+    # the schema is one or more image_columns (URL/path/bytes) + the text columns
+    # listed in dataset_columns. List several image_columns for multi-image rows.
+    - name: "data/sft_vlm/example_training_image_url.csv"
+      image_columns: ["image"]
+      dataset_columns: ["question", "response"]
+
+  image_cache_dir: "data/vlm_image_cache"
+  image_fetch_timeout: 15
+  image_fetch_retries: 3
+  max_image_pixels: 1048576        # ~1MP; raise/lower to trade quality vs. memory
+
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
+  system_prompt: |
+    You are a helpful multimodal assistant. Answer the user's question based on the image.
+    Question: {question}
+    Response: {response}
+
+training:
+  algorithm: "sft_vlm"
+  output_dir: "models/gemma-4-31b-it-sft-lora-v1"
+
+  # ZeRO-3 + CPU offload shards/offloads the 31B base weights and optimizer state
+  # so LoRA SFT fits across multiple GPUs. Requires DeepSpeed to be installed.
+  deepspeed_config: "configs/deepspeed/zero3_config.json"
+
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8   # effective batch = 1 x 8 x num_gpus
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: -1                    # -1 = train for num_train_epochs
+  warmup_steps: 20
+
+  logging_steps: 5
+  save_steps: 50
+  eval_steps: 50
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true     # essential at this scale
+
+  dataloader_num_workers: 4
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+
+wandb:
+  enabled: false                                          # Enable W&B logging
+  project: "your-project"                                 # W&B project name
+  entity: "your-wandb-entity"                             # W&B username or team name
+  name: "Gemma-4-31B-it-LoRA-SFT"                         # Experiment name in W&B
+  tags: ["SFT", "sft_vlm", "gemma-4", "31B", "LoRA"]      # Tags for organizing experiments
+  api_key: null                                           # W&B API key (null = use WANDB_API_KEY env var or prior `wandb login`)
+  base_url: "https://api.wandb.ai"                        # W&B base URL (null = use WANDB_BASE_URL env var)
+
+# S3 Checkpoint Upload
+# Automatically uploads checkpoints and the final model to S3
+s3:
+  enabled: false                                         # Enable S3 checkpoint upload
+  bucket: "your-s3-bucket"                               # S3 bucket name
+  prefix: "checkpoints/gemma-4-31b-it-sft-lora-v1"       # S3 key prefix (folder path inside bucket)
+  region: null                                           # AWS region (null = use AWS_DEFAULT_REGION env var or boto3 default)
+  endpoint_url: null                                     # Custom S3-compatible endpoint (e.g. MinIO). null = AWS S3
+  upload_checkpoints: true                               # Upload intermediate checkpoints (at every save_steps)
+  upload_final_model: true                               # Upload the final model at end of training
+  delete_local_after_upload: false                       # Delete local checkpoint files after successful upload

--- a/recipes/training/sft_vlm/gemma_4_31b_it_qlora.yaml
+++ b/recipes/training/sft_vlm/gemma_4_31b_it_qlora.yaml
@@ -1,0 +1,101 @@
+# Multimodal (image + text) SFT recipe for Gemma-4-31B-it (dense VLM) with QLoRA.
+#
+# Algorithm: sft_vlm. Images are supplied as HTTP(S) URLs in the dataset and
+# fetched into PIL images at data-loading time. Because this is a ~31B model,
+# this recipe uses 4-bit QLoRA. The launcher uses torchrun (DDP) for multi-GPU
+# because quantization is enabled (bitsandbytes 4-bit is incompatible with the
+# DeepSpeed ZeRO-3 parameter sharding used by the non-quantized LoRA recipe).
+model:
+  base_model_name: "google/gemma-4-31B-it"            # HuggingFace VLM id or local path
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_4bit: true                                   # 4-bit QLoRA (requires CUDA + bitsandbytes)
+  bnb_4bit_compute_dtype: "bfloat16"
+  bnb_4bit_quant_type: "nf4"
+  bnb_4bit_use_double_quant: true
+  use_flash_attention: false
+
+  # Freeze the vision encoder; train the language model via LoRA adapters.
+  freeze_vision_tower: true
+
+  # LoRA / QLoRA configuration. Target the language-model attention projections.
+  use_lora: true
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.05
+  lora_target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    # Example dataset shipped with the repo: stable public image URLs + Q/A.
+    # Swap `name` for any HF/local/S3 dataset that has image column(s) and text
+    # columns. List several image_columns for multi-image rows.
+    - name: "data/sft_vlm/example_training_image_url.csv"
+      image_columns: ["image"]                  # column(s) holding image sources (URL/path/bytes)
+      dataset_columns: ["question", "response"] # text columns that fill the system_prompt template
+
+  # Cache downloaded images on disk so they are not re-fetched every epoch.
+  image_cache_dir: "data/vlm_image_cache"
+  image_fetch_timeout: 15
+  image_fetch_retries: 3
+  max_image_pixels: 1048576        # cap images at ~1MP to bound vision tokens / memory
+
+  # NOTE: max_length is forced to None internally for VLMs to avoid truncating
+  # image placeholder tokens. The text knobs below are unused by sft_vlm.
+  # system_prompt is a .format() template keyed by the dataset_columns names;
+  # {question} and {response} are filled per row from those columns. The whole
+  # rendered text is one training turn (no prompt/completion masking), so it
+  # includes the {response} target.
+  system_prompt: |
+    You are a helpful multimodal assistant. Answer the user's question based on the image.
+    Question: {question}
+    Response: {response}
+
+training:
+  algorithm: "sft_vlm"
+  output_dir: "models/gemma-4-31b-it-sft-qlora-v1"
+
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: -1
+  warmup_steps: 20
+
+  logging_steps: 1
+  save_steps: 50
+  eval_steps: 50
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true
+
+  dataloader_num_workers: 2
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+
+wandb:
+  enabled: false                                          # Enable W&B logging
+  project: "your-project"                                 # W&B project name
+  entity: "your-wandb-entity"                             # W&B username or team name
+  name: "Gemma-4-31B-it-SFT-QLoRA"                        # Experiment name in W&B
+  tags: ["SFT", "sft_vlm", "gemma-4", "31B", "QLoRA", "multimodal"]   # Tags for organizing experiments
+  api_key: null                                           # W&B API key (null = use WANDB_API_KEY env var or prior `wandb login`)
+  base_url: "https://api.wandb.ai"                        # W&B base URL (null = use WANDB_BASE_URL env var)
+
+# S3 Checkpoint Upload
+# Automatically uploads checkpoints and the final model to S3
+s3:
+  enabled: false                                         # Enable S3 checkpoint upload
+  bucket: "your-s3-bucket"                               # S3 bucket name
+  prefix: "checkpoints/gemma-4-31b-it-sft-qlora-v1"      # S3 key prefix (folder path inside bucket)
+  region: null                                           # AWS region (null = use AWS_DEFAULT_REGION env var or boto3 default)
+  endpoint_url: null                                     # Custom S3-compatible endpoint (e.g. MinIO). null = AWS S3
+  upload_checkpoints: true                               # Upload intermediate checkpoints (at every save_steps)
+  upload_final_model: true                               # Upload the final model at end of training
+  delete_local_after_upload: false                       # Delete local checkpoint files after successful upload

--- a/requirements-cu130.txt
+++ b/requirements-cu130.txt
@@ -1,0 +1,16 @@
+# PyTorch built for CUDA 13.0.
+#
+# torch is intentionally NOT declared in pyproject.toml so that FAI-RL stays
+# cross-platform (e.g. macOS has no CUDA) and does not lock users to one CUDA
+# build. Standard dependency metadata cannot pin an index URL, so the cu130
+# wheels are installed from here instead.
+#
+# Usage:
+#   pip install -r requirements-cu130.txt
+#   pip install -e ".[cuda]"
+#
+# For a different CUDA build, change the index URL below (e.g. cu121, cu124).
+
+--extra-index-url https://download.pytorch.org/whl/cu130
+torch
+torchvision==0.28.0

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -85,8 +85,26 @@ class SFTVLMTrainer(BaseTrainer):
 
         # Optionally freeze the vision encoder (standard for VLM SFT; also avoids
         # training the ViT under full fine-tuning).
+        frozen_tower_attr = None
         if getattr(self.config.model, "freeze_vision_tower", True):
-            self._freeze_vision_tower(self.model)
+            frozen_tower_attr = self._freeze_vision_tower(self.model)
+
+        # Keep LoRA out of the (frozen) vision tower. target_modules like q_proj
+        # match by name across the whole model, so without this PEFT tries to
+        # adapt the vision tower's attention -- whose projections are custom
+        # module types (e.g. Gemma4's Gemma4ClippableLinear) that PEFT can't wrap,
+        # raising "Target module ... is not supported". A regex string exclusion
+        # is required because a list only suffix-matches leaf names, not a subtree.
+        if (
+            getattr(self.config.model, "use_lora", False)
+            and frozen_tower_attr is not None
+            and not getattr(self.config.model, "lora_exclude_modules", None)
+        ):
+            self.config.model.lora_exclude_modules = rf"(.*\.)?{frozen_tower_attr}\..*"
+            self.logger.info(
+                "Excluding frozen vision tower from LoRA injection: "
+                f"lora_exclude_modules={self.config.model.lora_exclude_modules!r}"
+            )
 
         # Apply LoRA/QLoRA if enabled (reuses BaseTrainer helper).
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
@@ -96,7 +114,12 @@ class SFTVLMTrainer(BaseTrainer):
         self.logger.info("VLM and processor loaded successfully")
 
     def _freeze_vision_tower(self, model):
-        """Freeze the vision encoder submodule if one can be located."""
+        """Freeze the vision encoder submodule if one can be located.
+
+        Returns the attribute name of the frozen tower (e.g. "vision_tower"), or
+        None if no known vision submodule was found. Callers use the name to keep
+        LoRA from being injected into the frozen tower.
+        """
         # PEFT may wrap the model; reach through to the underlying module.
         base = getattr(model, "base_model", model)
         base = getattr(base, "model", base)
@@ -107,11 +130,12 @@ class SFTVLMTrainer(BaseTrainer):
                     for p in tower.parameters():
                         p.requires_grad_(False)
                     self.logger.info(f"Froze vision tower: {attr}")
-                    return
+                    return attr
         self.logger.warning(
             "freeze_vision_tower=true but no known vision submodule "
             f"({', '.join(_VISION_TOWER_ATTRS)}) was found; nothing frozen."
         )
+        return None
 
     # ------------------------------ data ------------------------------------
 

--- a/trainers/train.py
+++ b/trainers/train.py
@@ -358,6 +358,22 @@ def main():
             os.environ.get('WORLD_SIZE', '?'),
         )
     else:
+        # Single-GPU, non-distributed run. On a multi-GPU host, HF Trainer sees
+        # every visible GPU (torch.cuda.device_count() > 1), sets _n_gpu > 1, and
+        # silently wraps the model in torch.nn.DataParallel. DataParallel replicates
+        # the model per device and breaks VLMs whose vision tower is frozen: e.g.
+        # Qwen2.5-VL's get_image_features reads self.visual.dtype, which does
+        # `next(p.dtype for p in self.parameters() if p.is_floating_point())` and
+        # raises StopIteration on a replica with no trainable (float) params.
+        # Pin visibility to a single device so no DataParallel wrapping occurs.
+        # Set this before any torch CUDA call so device enumeration picks it up;
+        # honor an explicit user-provided CUDA_VISIBLE_DEVICES if present.
+        if 'CUDA_VISIBLE_DEVICES' not in os.environ:
+            os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+            logger.info(
+                "Single-GPU run: pinned CUDA_VISIBLE_DEVICES=0 to avoid nn.DataParallel "
+                "(pass --num-gpus N for multi-GPU DDP, or set CUDA_VISIBLE_DEVICES yourself)."
+            )
         logger.info("Running single-GPU training...")
 
     # Load recipe from file and/or CLI arguments


### PR DESCRIPTION
## Summary

Adds Gemma-4-31B support and fixes two issues that broke VLM LoRA training on multi-GPU hosts. Also reworks installation around an unpinned torch + a CUDA 13.

## VLM LoRA: exclude the frozen vision tower
target_modules (e.g. q_proj) match by name across the whole model, so PEFT tried to adapt the vision tower's attention – whose projections are custom module types (e.g. Gemma-4's Gemma4ClippableLinear) that PEFT can't wrap, raising Target module ... is not supported.

- New ModelConfig.lora_exclude_modules (str regex or List[str]), threaded into LoraConfig only when set (keeps compat with older PEFT).

- SFTVLMTrainer auto-populates it with a regex matching the frozen vision tower subtree when freeze_vision_tower is set and no explicit list is given; _freeze_vision_tower now returns the tower attr name.

## Single-GPU DataParallel fix
On a multi-GPU host, HF Trainer sees every visible GPU and silently wraps the model in nn.DataParallel, which breaks VLMs with a frozen vision tower (e.g. Qwen2.5-VL's get_image_features raises StopIteration on a replica with no float params). Non-distributed runs now pin CUDA_VISIBLE_DEVICES=0 (honoring any user-provided value) so no DataParallel wrapping occurs.