### PR TITLE
fix(inference): skip missing media cells during inferencing

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -33,6 +33,7 @@ from transformers import (
 from datasets import load_dataset
 from utils.api_utils import generate_response_by_api
 from utils.image_utils import fetch_image
+from utils.media_utils import collect_media_sources
 from utils.video_utils import fetch_video
 
 # Suppress Pydantic warnings from dependencies (TRL/transformers)
@@ -474,15 +475,9 @@ def fetch_example_images(config, example):
     so a single row may carry multiple images. Returns a list of RGB PIL images
     (possibly empty), each optionally downscaled to max_image_pixels.
     """
-    sources = []
-    for col in (config.image_columns or []):
-        raw = example.get(col)
-        if raw is None:
-            continue
-        elif isinstance(raw, (list, tuple)):
-            sources.extend(str(s) for s in raw if s is not None)
-        else:
-            sources.append(str(raw))
+    sources = collect_media_sources(
+        example.get(col) for col in (config.image_columns or [])
+    )
 
     images = []
     for s in sources:
@@ -505,15 +500,10 @@ def fetch_example_videos(config, example):
     or a list of them. Every video found across the columns (in order) is sampled
     to frames. Returns a list of frame arrays (possibly empty), one per video.
     """
-    sources = []
-    for col in (getattr(config, "video_columns", None) or []):
-        raw = example.get(col)
-        if raw is None:
-            continue
-        elif isinstance(raw, (list, tuple)):
-            sources.extend(str(s) for s in raw if s is not None)
-        else:
-            sources.append(str(raw))
+    sources = collect_media_sources(
+        example.get(col)
+        for col in (getattr(config, "video_columns", None) or [])
+    )
 
     videos = []
     for s in sources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.0"
+version = "0.2.1"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils.media_utils import collect_media_sources
+
+
+def test_collect_media_sources_skips_missing_scalar_values():
+    values = [
+        "https://example.com/image.jpg",
+        None,
+        float("nan"),
+        pd.NA,
+        "",
+        "   ",
+    ]
+
+    assert collect_media_sources(values) == ["https://example.com/image.jpg"]
+
+
+def test_collect_media_sources_flattens_lists_and_preserves_order():
+    values = [
+        ["s3://bucket/one.jpg", None, float("nan")],
+        "  s3://bucket/two.jpg  ",
+        ("s3://bucket/three.jpg", ""),
+    ]
+
+    assert collect_media_sources(values) == [
+        "s3://bucket/one.jpg",
+        "s3://bucket/two.jpg",
+        "s3://bucket/three.jpg",
+    ]

--- a/utils/media_utils.py
+++ b/utils/media_utils.py
@@ -1,0 +1,32 @@
+"""Helpers shared by multimodal inference inputs."""
+
+from typing import Any, Iterable
+
+import pandas as pd
+
+
+def _is_missing_media_source(value: Any) -> bool:
+    """Return whether a dataset cell contains no media source."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        # Non-scalar values can produce an array of booleans. Those are valid
+        # source objects here and remain subject to the fetcher's validation.
+        return False
+
+
+def collect_media_sources(values: Iterable[Any]) -> list[str]:
+    """Flatten media columns while dropping null, NaN, and empty cells."""
+    sources = []
+    for raw in values:
+        items = raw if isinstance(raw, (list, tuple)) else (raw,)
+        for item in items:
+            if _is_missing_media_source(item):
+                continue
+            sources.append(item.strip() if isinstance(item, str) else str(item))
+    return sources


### PR DESCRIPTION
### Changes:
- Ignore null, NaN, and empty values so sparse multimodal datasets do not lose otherwise valid inference rows.