### PR TITLE
fix(s3): explicit region overrides ambient AWS_REGION for s5cmd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.1"
+version = "0.2.2"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_s3_utils_region.py
+++ b/tests/test_s3_utils_region.py
@@ -1,0 +1,93 @@
+"""Regression tests for s5cmd region handling in utils.s3_utils.
+
+An explicitly configured ``region`` must win over the compute's ambient
+AWS_REGION/AWS_DEFAULT_REGION when invoking s5cmd. Otherwise a checkpoint
+upload to a us-east-1 bucket from a us-east-2 pod inherits us-east-2 and
+301-redirects (BucketRegionError).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils import s3_utils
+
+
+def _capture_s5cmd_env(monkeypatch, call):
+    """Force the s5cmd backend, capture the env passed to subprocess.run."""
+    captured = {}
+
+    def fake_run(argv, *args, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(s3_utils.shutil, "which", lambda _name: "/usr/bin/s5cmd")
+    monkeypatch.setattr(s3_utils.subprocess, "run", fake_run)
+    call()
+    return captured
+
+
+def test_upload_dir_region_overrides_ambient_aws_region(tmp_path, monkeypatch):
+    (tmp_path / "checkpoint.bin").write_text("weights")
+    # The pod's ambient region points at the wrong region for the bucket.
+    monkeypatch.setenv("AWS_REGION", "us-east-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+
+    captured = _capture_s5cmd_env(
+        monkeypatch,
+        lambda: s3_utils.upload_directory_to_s3(
+            str(tmp_path),
+            "ml-platform-generic",
+            "prefix",
+            region="us-east-1",
+            uploader="s5cmd",
+        ),
+    )
+
+    assert captured["env"]["AWS_REGION"] == "us-east-1"
+    assert captured["env"]["AWS_DEFAULT_REGION"] == "us-east-1"
+
+
+def test_upload_file_region_overrides_ambient_aws_region(tmp_path, monkeypatch):
+    local = tmp_path / "adapter_model.safetensors"
+    local.write_text("weights")
+    monkeypatch.setenv("AWS_REGION", "us-east-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+
+    captured = _capture_s5cmd_env(
+        monkeypatch,
+        lambda: s3_utils.upload_file_to_s3(
+            str(local),
+            "ml-platform-generic",
+            "prefix/adapter_model.safetensors",
+            region="us-east-1",
+            uploader="s5cmd",
+        ),
+    )
+
+    assert captured["env"]["AWS_REGION"] == "us-east-1"
+    assert captured["env"]["AWS_DEFAULT_REGION"] == "us-east-1"
+
+
+def test_download_region_overrides_ambient_aws_region(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_REGION", "us-east-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+
+    captured = _capture_s5cmd_env(
+        monkeypatch,
+        lambda: s3_utils.download_directory_from_s3(
+            "s3://ml-platform-generic/prefix",
+            str(tmp_path / "out"),
+            region="us-east-1",
+            downloader="s5cmd",
+        ),
+    )
+
+    assert captured["env"]["AWS_REGION"] == "us-east-1"
+    assert captured["env"]["AWS_DEFAULT_REGION"] == "us-east-1"

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -87,8 +87,14 @@ def upload_directory_to_s3(
             argv.extend(["--endpoint-url", endpoint_url])
         argv.extend(["--numworkers", "256", "run"])
         env = os.environ.copy()
-        if region and "AWS_REGION" not in env and "AWS_DEFAULT_REGION" not in env:
+        if region:
+            # An explicitly configured region must win over the compute's
+            # ambient AWS_REGION/AWS_DEFAULT_REGION: the target bucket's region
+            # is unrelated to where the job happens to run. Without this, an
+            # s5cmd transfer to a us-east-1 bucket from a us-east-2 pod inherits
+            # us-east-2 and 301-redirects (BucketRegionError).
             env["AWS_REGION"] = region
+            env["AWS_DEFAULT_REGION"] = region
         result = subprocess.run(argv, input=manifest, text=True, env=env, capture_output=True)
         if result.returncode != 0:
             raise RuntimeError(
@@ -291,8 +297,14 @@ def download_directory_from_s3(
         # s5cmd sync handles recursive directory copies efficiently
         argv.extend(["sync", f"s3://{bucket}/{prefix}/*", f"{local_dir}/"])
         env = os.environ.copy()
-        if region and "AWS_REGION" not in env and "AWS_DEFAULT_REGION" not in env:
+        if region:
+            # An explicitly configured region must win over the compute's
+            # ambient AWS_REGION/AWS_DEFAULT_REGION: the target bucket's region
+            # is unrelated to where the job happens to run. Without this, an
+            # s5cmd transfer to a us-east-1 bucket from a us-east-2 pod inherits
+            # us-east-2 and 301-redirects (BucketRegionError).
             env["AWS_REGION"] = region
+            env["AWS_DEFAULT_REGION"] = region
         result = subprocess.run(argv, env=env, capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError(
@@ -403,8 +415,14 @@ def upload_file_to_s3(
             argv.extend(["--endpoint-url", endpoint_url])
         argv.extend(["cp", local_path, f"s3://{bucket}/{s3_key}"])
         env = os.environ.copy()
-        if region and "AWS_REGION" not in env and "AWS_DEFAULT_REGION" not in env:
+        if region:
+            # An explicitly configured region must win over the compute's
+            # ambient AWS_REGION/AWS_DEFAULT_REGION: the target bucket's region
+            # is unrelated to where the job happens to run. Without this, an
+            # s5cmd transfer to a us-east-1 bucket from a us-east-2 pod inherits
+            # us-east-2 and 301-redirects (BucketRegionError).
             env["AWS_REGION"] = region
+            env["AWS_DEFAULT_REGION"] = region
         result = subprocess.run(argv, env=env, capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
## Problem

Training checkpoint uploads fail in the **us-east-2 (use2)** cluster with:

```
BucketRegionError: incorrect region, the bucket is not in 'us-east-2' region ...
bucket is in 'us-east-1' region  status code: 301
```

The `ml-platform-generic` bucket is in **us-east-1**. The recipe correctly sets `s3.region: us-east-1`, but the three s5cmd sites in `utils/s3_utils.py` only applied it when the pod had **no** ambient region:

```python
if region and "AWS_REGION" not in env and "AWS_DEFAULT_REGION" not in env:
    env["AWS_REGION"] = region
```

In a us-east-2 cluster the pod always has `AWS_REGION=us-east-2` (EKS/IRSA default), so the configured region was silently dropped, s5cmd inherited us-east-2, and the us-east-1 bucket 301-redirected. Inference was unaffected because its result upload falls back to the boto3 client, where `region_name` always wins.

## Fix

A configured `region` is a property of the *target bucket*, not the compute it runs on, so it must always win. Set both `AWS_REGION` and `AWS_DEFAULT_REGION` from the argument in all three s5cmd sites (upload dir, upload file, download).

## Tests

Added `tests/test_s3_utils_region.py` — asserts the s5cmd subprocess env carries the configured region even when the ambient env points elsewhere, for all three paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)