### PR TITLE
feat(deepspeed): add no-offload zero3_auto config

### DIFF
--- a/configs/deepspeed/zero3_auto_config.json
+++ b/configs/deepspeed/zero3_auto_config.json
@@ -1,0 +1,23 @@
+{
+    "zero_optimization": {
+        "stage": 3,
+        "overlap_comm": true,
+        "contiguous_gradients": true,
+        "reduce_bucket_size": 5e8,
+        "stage3_prefetch_bucket_size": 5e8,
+        "stage3_param_persistence_threshold": 1e6,
+        "sub_group_size": 1e9,
+        "stage3_max_live_parameters": 1e9,
+        "stage3_max_reuse_distance": 1e9,
+        "stage3_gather_16bit_weights_on_model_save": true
+    },
+    "gradient_accumulation_steps": "auto",
+    "gradient_clipping": 1.0,
+    "steps_per_print": 10,
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "wall_clock_breakdown": false,
+    "bf16": {
+        "enabled": true
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.2"
+version = "0.2.3"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_deepspeed_configs.py
+++ b/tests/test_deepspeed_configs.py
@@ -1,0 +1,77 @@
+"""Contract tests for the shipped DeepSpeed configs.
+
+These lock down the two ZeRO-3 variants the ml-platform recipe builder points
+VLM LoRA at:
+
+* ``zero3_config.json`` — ZeRO-3 **with** CPU offload of params + optimizer
+  state (the low-VRAM escape hatch).
+* ``zero3_auto_config.json`` — ZeRO-3 with **no** CPU offload; shards the base
+  entirely on-GPU. This is the default for high-VRAM sharded LoRA / full-FT.
+  CPU offload deadlocks the ZeRO-3 param all-gather for large Gemma4 VLMs on
+  B200, so removing offload is what makes full bf16 LoRA of a ~60GB VLM train.
+
+Both configs ship inside the FAI-RL package (``configs/`` is a package and
+``pyproject.toml`` package-data globs ``*.json``), so the trainer can resolve
+``training.deepspeed_config`` relative to the package root.
+"""
+
+import json
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "configs" / "deepspeed"
+
+
+def _load(name):
+    with open(CONFIG_DIR / name) as f:
+        return json.load(f)
+
+
+def test_both_configs_are_valid_json_and_present():
+    assert (CONFIG_DIR / "zero3_config.json").is_file()
+    assert (CONFIG_DIR / "zero3_auto_config.json").is_file()
+    # Both parse as JSON objects.
+    assert isinstance(_load("zero3_config.json"), dict)
+    assert isinstance(_load("zero3_auto_config.json"), dict)
+
+
+def test_zero3_config_offloads_params_and_optimizer_to_cpu():
+    zero = _load("zero3_config.json")["zero_optimization"]
+    assert zero["stage"] == 3
+    assert zero["offload_param"]["device"] == "cpu"
+    assert zero["offload_optimizer"]["device"] == "cpu"
+
+
+def test_zero3_auto_config_is_stage3_without_any_cpu_offload():
+    zero = _load("zero3_auto_config.json")["zero_optimization"]
+    assert zero["stage"] == 3
+    # The whole point of the no-offload variant: neither key may be present,
+    # otherwise the ZeRO-3 param all-gather can deadlock on large VLMs.
+    assert "offload_param" not in zero
+    assert "offload_optimizer" not in zero
+
+
+def test_no_offload_config_matches_offload_config_except_offload_keys():
+    """The no-offload variant must be the offload config with only the two
+    ``offload_*`` keys removed — nothing else may drift between them."""
+    offload = _load("zero3_config.json")
+    no_offload = _load("zero3_auto_config.json")
+
+    offload_zero = dict(offload["zero_optimization"])
+    offload_zero.pop("offload_param")
+    offload_zero.pop("offload_optimizer")
+    assert offload_zero == no_offload["zero_optimization"]
+
+    # Every non-zero_optimization top-level key is identical.
+    for key in offload:
+        if key == "zero_optimization":
+            continue
+        assert offload[key] == no_offload[key], key
+    assert set(offload) == set(no_offload)
+
+
+def test_no_offload_config_keeps_bf16_and_auto_batch():
+    cfg = _load("zero3_auto_config.json")
+    assert cfg["bf16"]["enabled"] is True
+    assert cfg["train_batch_size"] == "auto"
+    assert cfg["train_micro_batch_size_per_gpu"] == "auto"
+    assert cfg["gradient_accumulation_steps"] == "auto"


### PR DESCRIPTION
## Summary

Adds `configs/deepspeed/zero3_auto_config.json` — a ZeRO-3 DeepSpeed config
identical to the existing `zero3_config.json` **except** that the
`offload_param` and `offload_optimizer` keys are removed. It shards
parameters + optimizer state entirely on-GPU with **no CPU offload**.

Also bumps the package `version` to `0.2.3` and adds
`tests/test_deepspeed_configs.py` locking down the offload-vs-no-offload shape
of both shipped configs.

## Why

Full (unquantized) **bf16 LoRA** — and full fine-tuning — of large **dense**
VLMs such as `google/gemma-4-31B-it` (~62 GB bf16) currently has no viable
multi-GPU path with the two existing options:

- **Plain DDP** (`deepspeed_config` unset) replicates the full base on every
  rank and **OOMs host RAM** during model load (each rank loads a ~200+ GB
  fp32→bf16 peak; 8 replicas cross the node's memory kill threshold).
- **ZeRO-3 with CPU offload** (`zero3_config.json`) deterministically
  **deadlocks the parameter all-gather** (`_ALLGATHER_BASE`) at step 0 — the
  NCCL watchdog aborts every rank after the 30-minute collective timeout. This
  reproduces with gradient checkpointing both on and off (same `SeqNum`, same
  tensor shapes), proving the hang is in the offload gather itself, not the
  checkpoint recompute path.

An 8×B200 node has **1440 GB VRAM**, so ZeRO-3 fits the ~62 GB base fully
on-GPU with room to spare. Removing CPU offload eliminates **both** failure
modes: the OOM (sharded load instead of replica-per-rank) and the all-gather
deadlock (no CPU↔GPU staging in the collective path).

`gemma-4-31B-it` is **dense**; the MoE sibling (`gemma4-26b-a4b-it`) is a
different architecture. This config targets the dense high-VRAM sharded-LoRA
case. MoE VLM LoRA under ZeRO-3 is known-fragile regardless of offload and may
still need plain DDP (`*_lora_ddp.yaml`) on high-VRAM GPUs — that is a separate
concern and not addressed here.

## Packaging

`configs/` is a package and `pyproject.toml` `[tool.setuptools.package-data]`
globs `*.json`, so the new file ships automatically. Verified by building the
wheel and confirming `configs/deepspeed/zero3_auto_config.json` is present.

## Consumer

Selected by the ml-platform LLM-Finetune recipe builder as the default
DeepSpeed config for multimodal (VLM) LoRA on high-VRAM GPUs:
**Roblox/ml-platform#1869** (github.rbx.com). That PR installs FAI-RL unpinned
at job submit, so it picks up `0.2.3` automatically once it is on the
Artifactory `pypi-all` proxy.

## Test plan

- [x] `pytest tests/test_deepspeed_configs.py` → 5 passed (asserts
  `zero3_config.json` has `offload_param`+`offload_optimizer` at `device: cpu`,
  and `zero3_auto_config.json` is `stage: 3` with neither offload key; also
  that the two configs are identical apart from the two removed keys).
- [x] `python -m build --wheel` succeeds and the wheel includes the new config.
- [ ] (gated) cut the `0.2.3` GitHub release → PyPI → Artifactory `pypi-all`
  sync, then submit a full bf16 LoRA `gemma4-31b` job on 8×B200 and confirm it
  trains past step 0.

> Note: this repo has a pre-existing repo-root `__init__.py` that makes bare
> `pytest` from the repo root treat the root as a package and fail collection
> for **all** existing tests; the config tests here are self-contained (stdlib
> only) and were run with `--import-mode=importlib`. Left untouched to keep this
> PR minimal.
