### PR TITLE
fix(trainer): load non-quantized DDP models GPU-direct via device_map

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -467,6 +467,22 @@ class BaseTrainer(ABC):
                     self.logger.info("Using device_map=auto for quantized model (no DeepSpeed, no CUDA).")
             else:
                 self.logger.info("DeepSpeed detected; not setting device_map to let DeepSpeed place parameters.")
+        elif using_deepspeed:
+            # Non-quantized + DeepSpeed (e.g. ZeRO-3 partitioned load): let
+            # DeepSpeed place/partition parameters. Setting device_map here would
+            # fight zero.Init sharding, so leave it unset.
+            self.logger.info("DeepSpeed detected; not setting device_map to let DeepSpeed place parameters.")
+        elif is_cuda_available():
+            # Full-precision (non-quantized) plain DDP / single-GPU without
+            # DeepSpeed. Load each rank's replica directly onto its own GPU.
+            # Without this, from_pretrained materializes the ENTIRE model on the
+            # host (device_map unset) on every rank, so N concurrent torchrun
+            # ranks OOM the host on large models. Mirrors the quantized branch
+            # above (proven on the QLoRA DDP path); the whole model stays on one
+            # device, so DDP wraps it normally and only gradients are all-reduced.
+            current_device = torch.cuda.current_device()
+            model_kwargs["device_map"] = {"": current_device}
+            self.logger.info(f"Using device_map={{'': {current_device}}} for full-precision model (no DeepSpeed).")
         elif is_mps_available():
             # For MPS, we need to explicitly set device_map for proper device placement
             model_kwargs["device_map"] = "mps"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.3"
+version = "0.2.4"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_prepare_model_kwargs.py
+++ b/tests/test_prepare_model_kwargs.py
@@ -1,0 +1,107 @@
+"""Tests for device placement in BaseTrainer.prepare_model_kwargs.
+
+The critical regression these lock down: on the full-precision (non-quantized),
+non-DeepSpeed CUDA path (plain DDP / single-GPU), from_pretrained must load each
+rank's replica directly onto its GPU via device_map={"": current_device}.
+Without it, device_map is unset and from_pretrained materializes the ENTIRE
+model on the host on every rank, so N concurrent torchrun ranks OOM the host on
+large models (the failure that blocked full bf16 LoRA on gemma-4-31B). The
+quantized branch already did this; here we assert the full-precision branch
+matches it while leaving the DeepSpeed and CPU paths untouched.
+
+Uses an unbound-method call on a minimal SimpleNamespace stub so the heavy
+BaseTrainer.__init__ (S3/Hub downloads, device detection) is not invoked.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import core.trainer_base as tb
+from core.trainer_base import BaseTrainer
+
+
+def _fake_trainer(deepspeed_config=None):
+    """Minimal stand-in carrying just the recipe fields prepare_model_kwargs reads."""
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            model=SimpleNamespace(
+                torch_dtype="bfloat16",
+                low_cpu_mem_usage=True,
+                ignore_mismatched_sizes=False,
+                use_flash_attention=False,
+            ),
+            training=SimpleNamespace(deepspeed_config=deepspeed_config),
+        ),
+        logger=MagicMock(),
+    )
+
+
+def _patch_env(monkeypatch, *, cuda=False, mps=False, device=0):
+    monkeypatch.setattr(tb, "is_cuda_available", lambda: cuda)
+    monkeypatch.setattr(tb, "is_mps_available", lambda: mps)
+    monkeypatch.setattr(tb, "resolve_transformers_attn_implementation", lambda *_a, **_k: None)
+    if cuda:
+        monkeypatch.setattr(tb.torch.cuda, "current_device", lambda: device)
+
+
+def test_full_precision_ddp_loads_gpu_direct(monkeypatch):
+    """Full bf16 + plain DDP (no quant, no DeepSpeed) on CUDA -> device_map to this rank's GPU."""
+    _patch_env(monkeypatch, cuda=True, device=3)
+    trainer = _fake_trainer(deepspeed_config=None)
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=None)
+
+    assert kwargs["device_map"] == {"": 3}
+    assert kwargs["torch_dtype"] is tb.torch.bfloat16
+    assert kwargs["low_cpu_mem_usage"] is True
+
+
+def test_full_precision_deepspeed_leaves_device_map_unset(monkeypatch):
+    """Non-quantized + DeepSpeed must NOT set device_map (DeepSpeed places/partitions params)."""
+    _patch_env(monkeypatch, cuda=True, device=0)
+    trainer = _fake_trainer(deepspeed_config="configs/deepspeed/zero3_auto_config.json")
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=None)
+
+    assert "device_map" not in kwargs
+
+
+def test_quantized_ddp_still_sets_device_map(monkeypatch):
+    """Regression: the quantized DDP path is unchanged (device_map to this rank's GPU)."""
+    _patch_env(monkeypatch, cuda=True, device=2)
+    trainer = _fake_trainer(deepspeed_config=None)
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=object())
+
+    assert kwargs["device_map"] == {"": 2}
+    assert "quantization_config" in kwargs
+
+
+def test_quantized_deepspeed_leaves_device_map_unset(monkeypatch):
+    """Regression: quantized + DeepSpeed still defers placement to DeepSpeed."""
+    _patch_env(monkeypatch, cuda=True, device=0)
+    trainer = _fake_trainer(deepspeed_config="configs/deepspeed/zero3_config.json")
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=object())
+
+    assert "device_map" not in kwargs
+
+
+def test_full_precision_cpu_leaves_device_map_unset(monkeypatch):
+    """No CUDA / no MPS (CPU or other backend): behavior preserved, no device_map."""
+    _patch_env(monkeypatch, cuda=False, mps=False)
+    trainer = _fake_trainer(deepspeed_config=None)
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=None)
+
+    assert "device_map" not in kwargs
+
+
+def test_full_precision_mps_sets_mps_device_map(monkeypatch):
+    """Apple Silicon path preserved: non-quant, no CUDA, MPS -> device_map='mps'."""
+    _patch_env(monkeypatch, cuda=False, mps=True)
+    trainer = _fake_trainer(deepspeed_config=None)
+
+    kwargs = BaseTrainer.prepare_model_kwargs(trainer, quantization_config=None)
+
+    assert kwargs["device_map"] == "mps"


### PR DESCRIPTION
## Summary
- `prepare_model_kwargs` set `device_map` **only** on the quantized (bitsandbytes) branch. For full-precision (bf16/fp16) training **without DeepSpeed** (plain DDP / single-GPU), `device_map` was left unset, so `from_pretrained` materializes the **entire model in host RAM on every rank**. N concurrent `torchrun` ranks then OOM the host on large models.
- This is exactly what blocked **full bf16 LoRA on gemma-4-31B**: 8-way plain DDP OOM'd the host during load, while the *same* job under **QLoRA succeeded** — because the quantized branch already sets `device_map={"": current_device}` (GPU-direct load).
- Fix: mirror that GPU-direct placement for the **non-quantized, non-DeepSpeed CUDA** path. Each rank loads its replica straight onto its own GPU; the whole model stays on one device, so DDP wraps it normally and only gradients are all-reduced.
- DeepSpeed path is unchanged (params placed/partitioned by DeepSpeed, incl. ZeRO-3 `zero.Init` sharding). CPU and MPS paths preserved.
- Bump version `0.2.3` → `0.2.4`.

## Why not ZeRO-3
ZeRO-3 shard-load avoids the host OOM but **deadlocks at step 0** on modality-heterogeneous multimodal batches (each rank issues a data-dependent number of sharded-param `_ALLGATHER_BASE` collectives → mismatch → NCCL watchdog abort). Verified twice on 8×B200 with `zero3_auto_config.json` (no offload). Plain DDP replicates instead of sharding, so it is immune to that divergence — this change makes plain DDP viable for large full-precision models.

## Test plan
- [x] `python -m pytest tests/test_prepare_model_kwargs.py tests/test_deepspeed_zero3_init.py` → 17 passed (6 new + 11 existing, no regressions). New tests lock down the `device_map` decision across quantized/full-precision × DeepSpeed/DDP/CPU/MPS.
- [ ] End-to-end: after release to PyPI (0.2.4), submit full bf16 LoRA on gemma-4-31B (8×B200, `deepspeedEnabled=false`) via the LLM Finetune Platform and confirm it trains **past step 0**.

Made with [Cursor](https://cursor.com)