### PR TITLE
fix: forward beta to GRPOConfig (GRPO ran with no KL term) and stop growing the vocab every run

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -488,16 +488,37 @@ class BaseTrainer(ABC):
             model_name = self.config.model.base_model_name
             
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        
-        # Set pad token if not present
+
+        # Establish a pad token WITHOUT growing the vocabulary. The previous code
+        # called add_special_tokens({"pad_token": "[PAD]"}) unconditionally, which
+        # made the `is None` check below dead and appended a brand-new token even
+        # to models that already pad (Qwen2.5 pads with <|endoftext|>). That grows
+        # len(tokenizer), forces the embedding resize below, and makes PEFT
+        # serialize the full embed_tokens + lm_head into every adapter checkpoint
+        # -- measured 561 MB instead of 18 MB for a 0.5B model, ~2 GB for an 8B.
+        #
+        # Reusing eos as pad keeps the vocab untouched for the common case of a
+        # tokenizer with no pad token (Llama 3, GPT-2); a fresh [PAD] is only
+        # added when there is no eos to borrow.
         if tokenizer.pad_token is None:
-            tokenizer.pad_token = tokenizer.eos_token
+            if tokenizer.eos_token is not None:
+                tokenizer.pad_token = tokenizer.eos_token
+            else:
+                tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         tokenizer.padding_side = "left"
-        tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-        
-        # Resize embeddings
-        model.resize_token_embeddings(len(tokenizer))
-        
+
+        # Only GROW the embedding matrix, never shrink it. Models are commonly
+        # published with vocab_size padded past len(tokenizer) for kernel
+        # alignment (Qwen2.5-0.5B: 151936 vs 151665), so an unconditional
+        # resize to len(tokenizer) would truncate real rows.
+        current_rows = model.get_input_embeddings().weight.shape[0]
+        if len(tokenizer) > current_rows:
+            self.logger.info(
+                f"Resizing embeddings {current_rows} -> {len(tokenizer)} "
+                f"(tokenizer has more tokens than the model's embedding matrix)"
+            )
+            model.resize_token_embeddings(len(tokenizer))
+
         return tokenizer
 
     @staticmethod

--- a/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
+++ b/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
@@ -59,6 +59,10 @@ training:
   output_dir: "models/qwen2_5-0_5B-grpo-mps-smoke"
 
   num_generations: 4                               # group size; keep global batch divisible by this
+  # KL coefficient toward the reference policy. Non-zero is essential here: at
+  # beta=0.0 this exact run drives held-out GSM8K accuracy DOWN from 44% to 17%
+  # by learning to emit bare digits in empty <think> tags. See scripts/ab_eval_grpo.py.
+  beta: 0.04
   per_device_train_batch_size: 4
   gradient_accumulation_steps: 2                   # global batch 8 -> 2 unique prompts per optimizer step
   learning_rate: 1.0e-4

--- a/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
+++ b/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
@@ -1,14 +1,14 @@
 # GRPO / RLVR smoke test sized for a single Apple Silicon Mac (MPS).
 #
-# Binding constraint on a Mac is NOT memory (64 GB unified is plenty here) —
-# it is rollout generation throughput. GRPO generates num_generations
-# completions per prompt per step through plain HF `generate` (no vLLM on
-# MPS), so wall-clock scales as:
+# MEASURED on an M3 Max / 64 GB (torch 2.13.0, transformers 5.8.0, trl 1.2.0):
+#   10 steps = 99 s wall clock (~10 s/step), 1.38 GB MPS allocated.
+#   Step time tracks ACTUAL completion length, not the cap: it fell 16 s -> 5 s
+#   over 10 steps as the policy learned to emit short well-formed answers.
+#   1 epoch over 64 rows = 32 optimizer steps (2 unique prompts/step) ~= 5.5 min.
 #
-#   max_steps  x  (per_device_train_batch_size x gradient_accumulation_steps)
-#              x  max_completion_length
-#
-# where max_completion_length = data.max_length - data.max_prompt_length.
+# Memory is nowhere near the limit — the constraint is rollout generation
+# throughput, since GRPO samples num_generations completions per prompt through
+# plain HF `generate` (no vLLM on MPS). Scale by steps, not by dataset size.
 #
 # Run:
 #   python trainers/train.py --recipe recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml --num-gpus 1
@@ -45,7 +45,12 @@ data:
       prompt_column: "question"
       answer_column: "answer"
 
-  max_length: 768                                  # 768 - 512 = 256-token completions (vs 1024 in the stock recipe)
+  # max_completion_length = max_length - max_prompt_length = 512.
+  # Measured: raising this cap from 256 -> 512 cost nothing (105 s vs 99 s for
+  # 10 steps) because the policy generates ~50-120 tokens anyway. At 256 the cap
+  # clipped 12-37% of completions early on, and a clipped completion never emits
+  # </answer>, so it silently forfeits the format reward. Keep the headroom.
+  max_length: 1024
   max_prompt_length: 512                           # GSM8K template prompt is ~200 tokens incl. system + 1-shot
   remove_unused_columns: false                     # must stay false: the reward fn needs the `answer` column
 
@@ -58,7 +63,10 @@ training:
   gradient_accumulation_steps: 2                   # global batch 8 -> 2 unique prompts per optimizer step
   learning_rate: 1.0e-4
   num_train_epochs: 1
-  max_steps: 10                                    # hard cap so the smoke run is bounded; raise to 100-200 to see reward move
+  # ~10 s/step measured. 10 steps (~100 s) is already enough to watch the XML
+  # format reward climb 0.03 -> ~0.50 (its ceiling). For a longer ablation:
+  # 128 steps ~= 22 min, and bump the slice above to train[:256] to stay 1 epoch.
+  max_steps: 10
   warmup_steps: 2                                  # stock recipe's 50 would exceed max_steps entirely
 
   logging_steps: 1

--- a/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
+++ b/recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml
@@ -1,0 +1,82 @@
+# GRPO / RLVR smoke test sized for a single Apple Silicon Mac (MPS).
+#
+# Binding constraint on a Mac is NOT memory (64 GB unified is plenty here) —
+# it is rollout generation throughput. GRPO generates num_generations
+# completions per prompt per step through plain HF `generate` (no vLLM on
+# MPS), so wall-clock scales as:
+#
+#   max_steps  x  (per_device_train_batch_size x gradient_accumulation_steps)
+#              x  max_completion_length
+#
+# where max_completion_length = data.max_length - data.max_prompt_length.
+#
+# Run:
+#   python trainers/train.py --recipe recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml --num-gpus 1
+
+model:
+  base_model_name: "Qwen/Qwen2.5-0.5B-Instruct"   # ~1 GB download, open weights, has a chat template
+  torch_dtype: "float16"                           # MPS prefers fp16; fall back to float32 if you see NaN losses
+  low_cpu_mem_usage: true
+  load_in_8bit: false                              # bitsandbytes is CUDA-only; the launcher force-disables these on MPS
+  load_in_4bit: false
+  use_flash_attention: false                       # flash-attn is CUDA-only
+
+  use_lora: true
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - q_proj
+    - v_proj
+    - k_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    # HF slice syntax passes straight through to load_dataset()
+    # (utils/dataset_utils.py:106), so this only downloads/keeps 64 rows.
+    - name: "openai/gsm8k"
+      subset: "main"
+      split: "train[:64]"
+      prompt_column: "question"
+      answer_column: "answer"
+
+  max_length: 768                                  # 768 - 512 = 256-token completions (vs 1024 in the stock recipe)
+  max_prompt_length: 512                           # GSM8K template prompt is ~200 tokens incl. system + 1-shot
+  remove_unused_columns: false                     # must stay false: the reward fn needs the `answer` column
+
+training:
+  algorithm: "grpo"
+  output_dir: "models/qwen2_5-0_5B-grpo-mps-smoke"
+
+  num_generations: 4                               # group size; keep global batch divisible by this
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 2                   # global batch 8 -> 2 unique prompts per optimizer step
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: 10                                    # hard cap so the smoke run is bounded; raise to 100-200 to see reward move
+  warmup_steps: 2                                  # stock recipe's 50 would exceed max_steps entirely
+
+  logging_steps: 1
+  save_steps: 1000                                 # effectively "final save only" for a 10-step run
+  eval_steps: 1000
+
+  bf16: false                                      # bf16 is auto-switched to fp16 on MPS (utils/device_utils.py)
+  fp16: true                                       # auto-disabled if torch < 2.8.0 (GradScaler+MPS requirement)
+  gradient_checkpointing: false                    # pure slowdown here; you have the memory
+
+  dataloader_num_workers: 0
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+  save_only_model: true
+  prediction_loss_only: true
+
+wandb:
+  enabled: false
+
+s3:
+  enabled: false

--- a/scripts/ab_eval_grpo.py
+++ b/scripts/ab_eval_grpo.py
@@ -9,7 +9,7 @@ difference is whether the LoRA adapter is attached. Greedy decoding, so the
 comparison is deterministic.
 
 Usage:
-  python scripts/ab_eval_grpo.py --adapter /tmp/grpo_trained --n 100
+  python scripts/ab_eval_grpo.py --arm nokl=/tmp/grpo_trained --arm kl=/tmp/grpo_fixed --n 100
 """
 import argparse
 import json
@@ -31,20 +31,39 @@ from trainers.templates.gsm8k_template import GSM8KTemplate
 
 
 def build_tokenizer(base_model):
-    """Replicate core/trainer_base.py:setup_tokenizer_with_model exactly, so the
-    adapter's resized embedding matches and both arms are prompted identically."""
+    """Mirror the FIXED core/trainer_base.py:setup_tokenizer_with_model: add a pad
+    token only when the tokenizer lacks one, so the vocab is never grown."""
     tok = AutoTokenizer.from_pretrained(base_model)
     if tok.pad_token is None:
-        tok.pad_token = tok.eos_token
+        tok.add_special_tokens({"pad_token": "[PAD]"})
     tok.padding_side = "left"
-    tok.add_special_tokens({"pad_token": "[PAD]"})
     return tok
+
+
+def adapter_embed_rows(adapter):
+    """Embedding rows baked into an adapter, or None if it carries none.
+
+    Pre-fix checkpoints contain a full resized embed_tokens; post-fix ones don't.
+    Detecting it lets one script score both layouts with no manual flag.
+    """
+    path = os.path.join(adapter, "adapter_model.safetensors")
+    if not os.path.exists(path):
+        return None
+    from safetensors import safe_open
+    with safe_open(path, "pt") as f:
+        for k in f.keys():
+            if k.endswith("embed_tokens.weight"):
+                return f.get_slice(k).get_shape()[0]
+    return None
 
 
 def load_model(base_model, tok, adapter=None, device="mps"):
     model = AutoModelForCausalLM.from_pretrained(base_model, dtype=torch.float16)
-    model.resize_token_embeddings(len(tok))
     if adapter:
+        rows = adapter_embed_rows(adapter)
+        if rows and rows != model.get_input_embeddings().weight.shape[0]:
+            print(f"    (legacy adapter carries a resized embedding: {rows} rows)")
+            model.resize_token_embeddings(rows)
         model = PeftModel.from_pretrained(model, adapter)
         model = model.merge_and_unload()
     return model.to(device).eval()
@@ -118,7 +137,8 @@ def summarize(name, rows):
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--base", default="Qwen/Qwen2.5-0.5B-Instruct")
-    p.add_argument("--adapter", required=True)
+    p.add_argument("--arm", action="append", default=[], metavar="NAME=PATH",
+                   help="repeatable; a 'base' arm (no adapter) is always run first")
     p.add_argument("--split", default="test")
     p.add_argument("--n", type=int, default=100)
     p.add_argument("--max-new-tokens", type=int, default=512)
@@ -139,8 +159,9 @@ def main():
         answers.append(f["answer"])
 
     print(f"Held-out GSM8K {args.split}[:{args.n}], greedy, max_new_tokens={args.max_new_tokens}\n")
+    arms = [("base", None)] + [tuple(a.split("=", 1)) for a in args.arm]
     results = {}
-    for name, adapter in [("base", None), ("grpo", args.adapter)]:
+    for name, adapter in arms:
         print(f"  generating: {name}")
         t0 = time.time()
         model = load_model(args.base, tok, adapter, args.device)
@@ -153,17 +174,19 @@ def main():
 
     print("\nRESULTS   strict = repo <answer>-tag extractor (what GRPO optimized)")
     print("          loose  = last-number-in-text (format-blind true accuracy)\n")
-    sb, lb = summarize("base", results["base"])
-    sg, lg = summarize("grpo", results["grpo"])
+    accs = {name: summarize(name, results[name]) for name, _ in arms}
 
-    for lbl, key, ab, ag in [("strict", "strict_correct", sb, sg),
-                             ("loose ", "loose_correct", lb, lg)]:
-        gained = sum(1 for b, g in zip(results["base"], results["grpo"])
-                     if g[key] and not b[key])
-        lost = sum(1 for b, g in zip(results["base"], results["grpo"])
-                   if b[key] and not g[key])
-        print(f"  {lbl}: {ag - ab:+6.1%}   ({gained} fixed, {lost} broken, "
-              f"net {gained - lost:+d}/{len(results['base'])})")
+    print("\n  vs base (paired, identical problems):")
+    for name, _ in arms[1:]:
+        for i, (lbl, key) in enumerate([("strict", "strict_correct"),
+                                        ("loose ", "loose_correct")]):
+            gained = sum(1 for b, g in zip(results["base"], results[name])
+                         if g[key] and not b[key])
+            lost = sum(1 for b, g in zip(results["base"], results[name])
+                       if b[key] and not g[key])
+            print(f"    {name:<6} {lbl}: {accs[name][i] - accs['base'][i]:+6.1%}   "
+                  f"({gained} fixed, {lost} broken, net {gained - lost:+d}"
+                  f"/{len(results['base'])})")
 
     with open(dump_path, "w") as f:
         json.dump({k: [dict(r) for r in v] for k, v in results.items()}, f, indent=1)

--- a/scripts/ab_eval_grpo.py
+++ b/scripts/ab_eval_grpo.py
@@ -1,0 +1,174 @@
+"""Paired base-vs-GRPO evaluation on held-out GSM8K.
+
+Scores both models with the repo's OWN template and reward functions
+(trainers/templates/gsm8k_template.py, trainers/rewards/*), so the numbers
+measure exactly what GRPO optimized rather than a separate eval regex.
+
+Both arms see identical prompts and identical tokenizer treatment; the only
+difference is whether the LoRA adapter is attached. Greedy decoding, so the
+comparison is deterministic.
+
+Usage:
+  python scripts/ab_eval_grpo.py --adapter /tmp/grpo_trained --n 100
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import torch
+from datasets import load_dataset
+from peft import PeftModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from trainers.rewards.accuracy_rewards import extract_answer
+from trainers.rewards.format_rewards import count_xml
+from trainers.templates.gsm8k_template import GSM8KTemplate
+
+
+def build_tokenizer(base_model):
+    """Replicate core/trainer_base.py:setup_tokenizer_with_model exactly, so the
+    adapter's resized embedding matches and both arms are prompted identically."""
+    tok = AutoTokenizer.from_pretrained(base_model)
+    if tok.pad_token is None:
+        tok.pad_token = tok.eos_token
+    tok.padding_side = "left"
+    tok.add_special_tokens({"pad_token": "[PAD]"})
+    return tok
+
+
+def load_model(base_model, tok, adapter=None, device="mps"):
+    model = AutoModelForCausalLM.from_pretrained(base_model, dtype=torch.float16)
+    model.resize_token_embeddings(len(tok))
+    if adapter:
+        model = PeftModel.from_pretrained(model, adapter)
+        model = model.merge_and_unload()
+    return model.to(device).eval()
+
+
+@torch.no_grad()
+def generate(model, tok, prompts, max_new_tokens, batch_size, device):
+    out = []
+    for i in range(0, len(prompts), batch_size):
+        batch = prompts[i : i + batch_size]
+        enc = tok(batch, return_tensors="pt", padding=True, truncation=True,
+                  max_length=1024).to(device)
+        gen = model.generate(**enc, max_new_tokens=max_new_tokens, do_sample=False,
+                             pad_token_id=tok.pad_token_id)
+        for j in range(len(batch)):
+            out.append(tok.decode(gen[j][enc["input_ids"].shape[1]:],
+                                  skip_special_tokens=True))
+        print(f"    {min(i + batch_size, len(prompts))}/{len(prompts)}", flush=True)
+    return out
+
+
+def norm(s):
+    """Normalize a numeric answer so 18,000 == 18000 and 7.0 == 7."""
+    s = s.replace(",", "").replace("$", "").strip().rstrip(".")
+    try:
+        f = float(s)
+        return str(int(f)) if f == int(f) else str(f)
+    except ValueError:
+        return s
+
+
+def last_number(text):
+    """Format-agnostic GSM8K extraction: the last number in the completion.
+    Needed because the repo's extract_answer requires <answer> tags, which the
+    BASE model never emits -- scoring it with the strict extractor reports 0%
+    regardless of whether the arithmetic was right."""
+    m = re.findall(r"-?\d[\d,]*\.?\d*", text)
+    return norm(m[-1]) if m else ""
+
+
+def score(completions, answers, tok):
+    """Score each completion two ways:
+      strict_correct  - the repo's <answer>-tag extractor (what GRPO optimized)
+      loose_correct   - last-number-in-text (true math accuracy, format-blind)
+    """
+    rows = []
+    for comp, ans in zip(completions, answers):
+        pred = extract_answer(comp)
+        rows.append({
+            "exact": 2.0 if pred == ans else 0.0,
+            "xml": count_xml(comp),
+            "digit": 0.5 if pred.isdigit() else 0.0,
+            "ntok": len(tok(comp)["input_ids"]),
+            "strict_correct": pred == ans,
+            "loose_correct": last_number(comp) == norm(ans),
+        })
+    return rows
+
+
+def summarize(name, rows):
+    n = len(rows)
+    mean = lambda k: sum(r[k] for r in rows) / n
+    strict = sum(r["strict_correct"] for r in rows) / n
+    loose = sum(r["loose_correct"] for r in rows) / n
+    print(f"  {name:<6} strict={strict:6.1%} ({sum(r['strict_correct'] for r in rows):>3}/{n})   "
+          f"loose={loose:6.1%} ({sum(r['loose_correct'] for r in rows):>3}/{n})   "
+          f"xml={mean('xml'):.3f}  digit={mean('digit'):.3f}  mean_tok={mean('ntok'):6.1f}")
+    return strict, loose
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--base", default="Qwen/Qwen2.5-0.5B-Instruct")
+    p.add_argument("--adapter", required=True)
+    p.add_argument("--split", default="test")
+    p.add_argument("--n", type=int, default=100)
+    p.add_argument("--max-new-tokens", type=int, default=512)
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--device", default="mps")
+    p.add_argument("--dump", default="/tmp/ab_eval_rows.json")
+    args = p.parse_args()
+    dump_path = args.dump
+
+    ds = load_dataset("openai/gsm8k", "main", split=f"{args.split}[:{args.n}]")
+    tok = build_tokenizer(args.base)
+
+    prompts, answers = [], []
+    for ex in ds:
+        f = GSM8KTemplate.format_for_training(ex, "question", "answer")
+        prompts.append(tok.apply_chat_template(f["prompt"], tokenize=False,
+                                               add_generation_prompt=True))
+        answers.append(f["answer"])
+
+    print(f"Held-out GSM8K {args.split}[:{args.n}], greedy, max_new_tokens={args.max_new_tokens}\n")
+    results = {}
+    for name, adapter in [("base", None), ("grpo", args.adapter)]:
+        print(f"  generating: {name}")
+        t0 = time.time()
+        model = load_model(args.base, tok, adapter, args.device)
+        comps = generate(model, tok, prompts, args.max_new_tokens, args.batch_size, args.device)
+        results[name] = score(comps, answers, tok)
+        json.dump(comps, open(f"/tmp/ab_completions_{name}.json", "w"), indent=1)
+        del model
+        torch.mps.empty_cache()
+        print(f"    done in {time.time() - t0:.0f}s")
+
+    print("\nRESULTS   strict = repo <answer>-tag extractor (what GRPO optimized)")
+    print("          loose  = last-number-in-text (format-blind true accuracy)\n")
+    sb, lb = summarize("base", results["base"])
+    sg, lg = summarize("grpo", results["grpo"])
+
+    for lbl, key, ab, ag in [("strict", "strict_correct", sb, sg),
+                             ("loose ", "loose_correct", lb, lg)]:
+        gained = sum(1 for b, g in zip(results["base"], results["grpo"])
+                     if g[key] and not b[key])
+        lost = sum(1 for b, g in zip(results["base"], results["grpo"])
+                   if b[key] and not g[key])
+        print(f"  {lbl}: {ag - ab:+6.1%}   ({gained} fixed, {lost} broken, "
+              f"net {gained - lost:+d}/{len(results['base'])})")
+
+    with open(dump_path, "w") as f:
+        json.dump({k: [dict(r) for r in v] for k, v in results.items()}, f, indent=1)
+    print(f"\n  per-example scores -> {dump_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/trainers/grpo_trainer.py
+++ b/trainers/grpo_trainer.py
@@ -175,6 +175,20 @@ class GRPOTrainer(BaseTrainer):
             # GRPO specific parameters
             num_generations=self.config.training.num_generations,
             max_completion_length=self.config.data.max_length - self.config.data.max_prompt_length,
+            # KL regularization toward the reference policy. Previously not
+            # forwarded at all, so GRPO always ran at TRL's default beta=0.0
+            # (no KL term) and training.beta was silently inert. With no anchor,
+            # the policy free-runs toward whatever the shaping rewards favor --
+            # on GSM8K it collapses to emitting bare digits inside empty <think>
+            # tags, which scores full format+digit reward while abandoning
+            # chain-of-thought.
+            #
+            # epsilon / epsilon_high / steps_per_generation are deliberately NOT
+            # forwarded here: their defaults in TrainingConfig (3e-4 / 4e-4 / 4)
+            # are the GSPO paper's values, and applying them to GRPO would
+            # silently tighten clipping from TRL's 0.2 to 3e-4. They stay
+            # GSPO-only until GRPO gets its own defaults.
+            beta=float(self.config.training.beta),
         )
 
     def setup_trainer(self):


### PR DESCRIPTION
# Fix GRPO KL regularization and per-checkpoint vocab growth

Found while running a GRPO/RLVR smoke test on Apple Silicon. Two independent bugs, each verified by execution, plus a reproducible ablation showing the first one silently destroys held-out accuracy.

## Bug 1 — GRPO ran with no KL penalty, and no knob could enable one

`grpo_trainer.py:setup_training_args` forwarded `num_generations` and `max_completion_length` but never `beta`. TRL 1.2.0's `GRPOConfig` defaults to `beta=0.0`, so **every GRPO run trained with the KL term switched off** and `training.beta` was silently inert. `gspo_trainer.py` already forwarded it; GRPO did not.

With nothing anchoring the policy to its reference, the shaping rewards are free to dominate. On GSM8K the policy learns that an empty `<think>` block plus a bare integer collects the full format reward (0.5) and digit reward (0.5):

```
[BASE, 216 tok]                          [GRPO beta=0.0, 22 tok]
1. Donuts: 3 × $68 = $204                <think>
2. Mini cupcakes: 2 × $80 = $160         1400
3. Mini cheesecakes: 6 × $55 = $330      </think>
Total = $204 + $160 + $330 = $694  ✓     <answer>
                                         1400
                                         </answer>  ✗
```

Training-time telemetry, same 32 steps and same data, only `beta` differs — the `kl` channel is exactly zero before the fix:

```
               beta=0.0 (before)      |     beta=0.04 (after)
 steps      len  entropy       kl     |    len  entropy       kl
  1-8     125.6    0.899   0.0000     |  138.3    1.034   0.0224
  9-16     92.6    0.750   0.0000     |  118.4    0.774   0.0488
 17-24     72.4    0.859   0.0000     |  100.6    0.603   0.0469
 25-32     86.4    0.809   0.0000     |  124.9    0.644   0.0440
```

`epsilon` / `epsilon_high` / `steps_per_generation` are deliberately **not** forwarded for GRPO: their `TrainingConfig` defaults (3e-4 / 4e-4 / 4) are the GSPO paper's values, and applying them to GRPO would silently tighten clipping from TRL's 0.2 to 3e-4. They stay GSPO-only until GRPO gets its own defaults.

## Bug 2 — every adapter checkpoint carried the full embedding matrix

`core/trainer_base.py:setup_tokenizer_with_model` called `add_special_tokens({"pad_token": "[PAD]"})` **unconditionally**, which made the preceding `if tokenizer.pad_token is None` check dead code. Qwen2.5 already pads with `<|endoftext|>`, so this appended a redundant token (`len(tokenizer)` 151665 → 151666). The unconditional `resize_token_embeddings(len(tokenizer))` then *changed* the embedding row count — for Qwen2.5-0.5B a **shrink** of the published matrix from 151936 to 151666 rows — so PEFT flagged the embedding as modified and serialized it into every checkpoint:

```
adapter total: 276,184,576 params
  135,892,736  base_model.model.model.embed_tokens.weight  [151666, 896]
  135,892,736  base_model.model.lm_head.weight             [151666, 896]
```

98.4% embeddings, for 4.4 M of actual LoRA. **561 MB per checkpoint** on a 0.5B model; ~2 GB on an 8B one, multiplied by `save_steps` and by S3 checkpoint upload where enabled.

The fix reuses `eos` as pad when a tokenizer has none (so Llama 3 / GPT-2 don't grow either) and only ever *grows* the embedding, never shrinks it — a naive `!=` guard would truncate Qwen's published 151936 rows down to 151665.

| | before | after |
|---|---|---|
| `adapter_model.safetensors` | 561 MB | **17.6 MB** |
| vocab growth, Qwen2.5 | 151665 → 151666 | none |
| vocab growth, GPT-2 | 50257 → 50258 | none |
| embedding resize | 151936 → 151666 (shrink) | not triggered |

## Ablation

Held-out GSM8K `test[:100]`, greedy, paired (identical problems every arm), 32-step runs over `train[:64]`, Qwen2.5-0.5B-Instruct + LoRA. Reproduce with `scripts/ab_eval_grpo.py`.

Two scorings are reported because the repo's `extract_answer` requires `<answer>` tags, which the base model never emits — scoring it strictly reports 0% no matter how good its arithmetic is:

- **strict** — the repo's `<answer>`-tag extractor, i.e. what GRPO actually optimizes
- **loose** — last number in the completion, i.e. format-blind true accuracy

```
  base   strict=  0.0% (  0/100)   loose= 44.0% ( 44/100)   xml=0.000  mean_tok= 209.9
  nokl   strict= 16.0% ( 16/100)   loose= 17.0% ( 17/100)   xml=0.500  mean_tok=  68.3
  kl     strict= 29.0% ( 29/100)   loose= 37.0% ( 37/100)   xml=0.424  mean_tok= 134.9
```

McNemar exact tests on the paired outcomes:

| comparison | metric | fixed / broken | p | verdict |
|---|---|---|---|---|
| `nokl` vs base | loose | 5 / 32 | <0.0001 | **significant regression** |
| `kl` vs base | loose | 11 / 18 | 0.265 | no measurable regression |
| `kl` vs `nokl` | loose | 23 / 3 | 0.00009 | **significant improvement** |
| `kl` vs `nokl` | strict | 17 / 4 | 0.0072 | **significant improvement** |

**What this shows:** forwarding `beta` converts a statistically significant −27 point accuracy regression into one that is statistically indistinguishable from the untrained base (−7 points, p=0.27), while significantly improving both the optimized metric (+13 points strict) and true accuracy (+20 points loose) over the current trainer.

**What this does not show:** the fixed run does not *beat* the base model on format-blind math (37% vs 44%). 32 steps on 64 prompts is a smoke test, not a training budget — the claim here is that the KL term stops GRPO from actively destroying the policy, not that this recipe improves reasoning.

## Also included

`recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml` — a GRPO recipe sized for a single Apple Silicon box (0.5B model, `train[:64]`, 32 steps ≈ 5 min, 1.4 GB unified memory), with measured throughput annotated. Useful as a CI-able smoke test for the RLVR path; the stock GRPO recipe pulls OpenMathInstruct-2's 1M-row split as a second dataset, which is not a smoke test.

`scripts/ab_eval_grpo.py` — the paired evaluator used above. Scores with the repo's own template and reward functions, and auto-detects whether an adapter carries a legacy resized embedding so pre- and post-fix checkpoints can be compared in one run.

## Reproduction

```bash
uv venv --python 3.12 .venv-mps
VIRTUAL_ENV=.venv-mps uv pip install torch torchvision==0.28.0
VIRTUAL_ENV=.venv-mps uv pip install -e .        # no [cuda] extra on macOS

# beta=0.0 arm (pre-fix behavior) vs beta=0.04 arm
python trainers/train.py --recipe recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml \
  --num-gpus 1 training.beta=0.0 training.output_dir=/tmp/nokl
python trainers/train.py --recipe recipes/training/grpo/qwen2_5_0_5B_mps_smoke.yaml \
  --num-gpus 1 training.output_dir=/tmp/kl

python scripts/ab_eval_grpo.py --arm nokl=/tmp/nokl --arm kl=/tmp/kl --n 100
```

Environment: M3 Max / 64 GB, macOS, torch 2.13.0, transformers 5.8.0, trl 1.2.0, peft 0.19.0.

Note on scope of testing: the `kl` arm above was trained on the exact code path in this PR for Qwen2.5 (which has a pad token, so the `eos` fallback branch is not reached). The `eos` fallback and the resize guard were verified separately against Qwen2.5 and GPT-2.

## Not addressed here

Found during the same audit, left out to keep this PR reviewable:

1. `DPOConfig` never receives `beta` either — `dpo_trainer.py` has zero references to it, so DPO always trains at TRL's default 0.1 and `training.beta` is silently ignored. Latent (no shipped DPO recipe sets it) but it is *the* DPO hyperparameter.
2. The documented `data.datasets[0].name=` override syntax does not work. `set_nested_value` (`utils/recipe_overrides.py:35`) splits only on `.`, producing a bogus `datasets[0]` key and a `TypeError`. Documented in 7 places across `trainers/README.md` and `recipes/training/README.md`.
3. `data.max_prompt_length` never truncates prompts for GRPO/GSPO — TRL 1.2.0's `GRPOConfig` has no such field. It only acts as the subtrahend for `max_completion_length`, so the recipe comment "Maximum length for prompts" is misleading.
4. SFT / CPT / SFT_VLM silently drop `save_only_model` and `prediction_loss_only`.
5. Reward-function edge cases: `exact_match` is raw string equality, so 8/1000 GSM8K gold answers containing commas can never match; `count_xml`'s trailing penalty is unbounded (5000 trailing chars → −4.5, swamping the +2.0 correctness reward); `extract_answer` returns the entire completion when no `<answer>` tag is present; `digit_reward` rejects negatives and decimals.
6. `custom_reward_func` ships in the live reward list returning a constant `0.0`.

Happy to split any of these into follow-ups.
