### PR TITLE
fix(vlm): ignore empty image and video cells

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.3"
+version = "0.2.4"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_sft_vlm_trainer.py
+++ b/tests/test_sft_vlm_trainer.py
@@ -1,0 +1,71 @@
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from datasets import Dataset
+
+# Ensure the repo root is importable so `trainers.*` resolves.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from trainers.sft_vlm_trainer import SFTVLMTrainer
+
+
+def test_media_source_coercion_ignores_empty_values():
+    empty_values = [None, "", " \t\n", b"", math.nan]
+
+    for value in empty_values:
+        assert SFTVLMTrainer._coerce_image_source(value) is None
+        assert SFTVLMTrainer._coerce_video_source(value) is None
+
+
+def test_media_source_coercion_strips_valid_paths():
+    assert (
+        SFTVLMTrainer._coerce_image_source("  s3://bucket/image.jpg  ")
+        == "s3://bucket/image.jpg"
+    )
+    assert (
+        SFTVLMTrainer._coerce_video_source("\ts3://bucket/video.mp4\n")
+        == "s3://bucket/video.mp4"
+    )
+
+
+def test_normalize_dataset_keeps_valid_media_when_other_cells_are_empty():
+    raw = Dataset.from_dict(
+        {
+            "image_1": ["", "  ", ""],
+            "image_2": ["s3://bucket/image.jpg", "", ""],
+            "video": ["", "s3://bucket/video.mp4", ""],
+            "prompt": ["one", "two", "three"],
+            "response": ["a", "b", "c"],
+        }
+    )
+    dataset_info = SimpleNamespace(
+        image_columns=["image_1", "image_2"],
+        video_columns=["video"],
+        dataset_columns=["prompt", "response"],
+    )
+    trainer = object.__new__(SFTVLMTrainer)
+    trainer._split_mode = True
+    trainer.config = SimpleNamespace(
+        data=SimpleNamespace(
+            system_prompt=None,
+            user_prompt="{prompt}",
+            assistant_prompt="{response}",
+        )
+    )
+
+    normalized = trainer._normalize_dataset(raw, dataset_info)
+
+    assert normalized["_image_sources"] == [
+        ["s3://bucket/image.jpg"],
+        [],
+        [],
+    ]
+    assert normalized["_video_sources"] == [
+        [],
+        ["s3://bucket/video.mp4"],
+        [],
+    ]

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -1,4 +1,5 @@
-import io, os, sys
+import io, math, os, sys
+from numbers import Real
 from typing import Optional, List, Any
 
 from datasets import concatenate_datasets
@@ -142,6 +143,17 @@ class SFTVLMTrainer(BaseTrainer):
     # ------------------------------ data ------------------------------------
 
     @staticmethod
+    def _is_empty_media_source(s: Any) -> bool:
+        """Return whether a media cell has no usable source."""
+        if s is None:
+            return True
+        if isinstance(s, str):
+            return not s.strip()
+        if isinstance(s, (bytes, bytearray)):
+            return not s
+        return isinstance(s, Real) and math.isnan(s)
+
+    @staticmethod
     def _coerce_image_source(s: Any):
         """Normalize one image cell into an Arrow-serializable source.
 
@@ -157,10 +169,10 @@ class SFTVLMTrainer(BaseTrainer):
         """
         from PIL import Image
 
-        if s is None:
+        if SFTVLMTrainer._is_empty_media_source(s):
             return None
         if isinstance(s, str):
-            return s
+            return s.strip()
         if isinstance(s, (bytes, bytearray)):
             return bytes(s)
         if isinstance(s, Image.Image):
@@ -186,10 +198,10 @@ class SFTVLMTrainer(BaseTrainer):
         the HF ``{'path'/'url'/'video'}`` dict pass through; everything else is
         stringified. Returns ``None`` for empty cells so callers can drop them.
         """
-        if s is None:
+        if SFTVLMTrainer._is_empty_media_source(s):
             return None
         if isinstance(s, str):
-            return s
+            return s.strip()
         if isinstance(s, dict):
             for key in ("video", "path", "url"):
                 if s.get(key) is not None:


### PR DESCRIPTION
## Summary
- Treat blank, whitespace-only, empty-bytes, and NaN image/video cells as missing instead of fetchable paths.
- Keep a row when at least one selected image or video cell is valid; still drop rows with no usable media.
- Bump the package version to 0.2.4.

## Test plan
- [ ] Run `python -c "import runpy; t=runpy.run_path('tests/test_sft_vlm_trainer.py'); t['test_media_source_coercion_ignores_empty_values'](); t['test_media_source_coercion_strips_valid_paths'](); t['test_normalize_dataset_keeps_valid_media_when_other_cells_are_empty']()"` from the repo root.
- [ ] Train `sft_vlm` on a CSV with some empty `image_*` / `video_*` cells and confirm those cells are skipped rather than fetched.
- [ ] Confirm rows that still have at least one valid S3/HTTP media path remain in the dataset.


Made with [Cursor](https://cursor.com)