### PR TITLE
fix(vlm): pass video fps metadata to processor

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -498,7 +498,8 @@ def fetch_example_videos(config, example):
 
     video_columns lists one or more columns; each cell may hold a single URL/path
     or a list of them. Every video found across the columns (in order) is sampled
-    to frames. Returns a list of frame arrays (possibly empty), one per video.
+    to frames. Returns ``(videos, video_metadata)``: a list of frame arrays
+    (possibly empty) and a parallel list of metadata dicts (or None entries).
     """
     sources = collect_media_sources(
         example.get(col)
@@ -506,8 +507,9 @@ def fetch_example_videos(config, example):
     )
 
     videos = []
+    metadata = []
     for s in sources:
-        frames = fetch_video(
+        frames, meta = fetch_video(
             s,
             num_frames=getattr(config, "video_num_frames", 8),
             fps=getattr(config, "video_fps", None),
@@ -517,12 +519,14 @@ def fetch_example_videos(config, example):
             s3_region=getattr(config, "video_s3_region", None),
             s3_endpoint_url=getattr(config, "video_s3_endpoint_url", None),
             backend=getattr(config, "video_backend", "pyav"),
+            return_metadata=True,
         )
         videos.append(frames)
-    return videos
+        metadata.append(meta)
+    return videos, metadata
 
 
-def generate_vlm_response(model, processor, prompt_text: str, images, config, system_text: str = None, videos=None):
+def generate_vlm_response(model, processor, prompt_text: str, images, config, system_text: str = None, videos=None, video_metadata=None):
     """Generate a response from a VLM given a text prompt and image(s)/video(s).
 
     Builds a single user turn containing one image placeholder per image and one
@@ -541,12 +545,16 @@ def generate_vlm_response(model, processor, prompt_text: str, images, config, sy
     messages.append({"role": "user", "content": content})
 
     text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-    inputs = processor(
-        text=[text],
-        images=images if images else None,
-        videos=videos if videos else None,
-        return_tensors="pt",
-    ).to(model.device)
+    processor_kwargs = {
+        "text": [text],
+        "images": images if images else None,
+        "videos": videos if videos else None,
+        "return_tensors": "pt",
+    }
+    if videos and video_metadata:
+        processor_kwargs["video_metadata"] = video_metadata
+        processor_kwargs["do_sample_frames"] = False
+    inputs = processor(**processor_kwargs).to(model.device)
 
     input_token_length = inputs.input_ids.shape[1]
     tokenizer = getattr(processor, "tokenizer", processor)
@@ -726,11 +734,11 @@ def run_inference(config, debug=False):
                 elif is_vlm:
                     # `tokenizer` holds the processor in VLM mode.
                     images = fetch_example_images(config, example)
-                    videos = fetch_example_videos(config, example)
+                    videos, video_metadata = fetch_example_videos(config, example)
                     if messages is not None:
-                        response = generate_vlm_response(model, tokenizer, user_text, images, config, system_text=system_text, videos=videos)
+                        response = generate_vlm_response(model, tokenizer, user_text, images, config, system_text=system_text, videos=videos, video_metadata=video_metadata)
                     else:
-                        response = generate_vlm_response(model, tokenizer, full_prompt, images, config, videos=videos)
+                        response = generate_vlm_response(model, tokenizer, full_prompt, images, config, videos=videos, video_metadata=video_metadata)
                 else:
                     if messages is not None:
                         response = generate_response(model, tokenizer, config=config, messages=messages)

--- a/tests/test_video_utils.py
+++ b/tests/test_video_utils.py
@@ -77,6 +77,44 @@ def test_fetch_video_rejects_unknown_type():
         video_utils.fetch_video(12345)
 
 
+def test_as_video_metadata_dict_keeps_fps_and_frame_indices():
+    class FakeMeta:
+        def __iter__(self):
+            return iter(
+                ["total_num_frames", "fps", "width", "height", "duration", "frames_indices"]
+            )
+
+        def __getitem__(self, key):
+            return {
+                "total_num_frames": 240,
+                "fps": 30.0,
+                "width": 1280,
+                "height": 720,
+                "duration": 8.0,
+                "frames_indices": [0, 8, 16],
+            }[key]
+
+    got = video_utils.as_video_metadata_dict(FakeMeta())
+    assert got["fps"] == 30.0
+    assert got["total_num_frames"] == 240
+    assert got["frames_indices"] == [0, 8, 16]
+
+
+def test_fetch_video_return_metadata_includes_decode_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(video_utils, "_fetch_url", lambda url, t, r: b"X")
+
+    def fake_decode(path, *, num_frames, fps, backend):
+        return "frames", {"fps": 24.0, "total_num_frames": 48, "frames_indices": [0, 2, 4]}
+
+    monkeypatch.setattr(video_utils, "_decode", fake_decode)
+    frames, metadata = video_utils.fetch_video(
+        "https://e/x.mp4", num_frames=3, return_metadata=True
+    )
+    assert frames == "frames"
+    assert metadata["fps"] == 24.0
+    assert metadata["frames_indices"] == [0, 2, 4]
+
+
 # --------------------------- collator behavior ----------------------------
 
 def test_video_injecting_proxy_only_injects_on_image_calls():
@@ -90,7 +128,8 @@ def test_video_injecting_proxy_only_injects_on_image_calls():
             return "out"
 
     videos = [["frames"]]
-    proxy = _VideoInjectingProcessor(FakeProc(), videos)
+    metadata = [[{"fps": 30.0, "frames_indices": [0, 10]}]]
+    proxy = _VideoInjectingProcessor(FakeProc(), videos, video_metadata=metadata)
 
     # Prompt/LM call carries images -> videos injected.
     proxy(images=None, text=["t"])
@@ -98,12 +137,41 @@ def test_video_injecting_proxy_only_injects_on_image_calls():
     proxy(text=["c"])
 
     assert seen[0].get("videos") == videos
+    assert seen[0].get("video_metadata") == metadata
+    assert seen[0].get("do_sample_frames") is False
     assert "videos" not in seen[1]
+    assert "video_metadata" not in seen[1]
 
 
 def test_extract_videos_none_when_empty_else_list():
     from trainers.vlm_collator import VideoAwareVLMCollator
 
-    assert VideoAwareVLMCollator._extract_videos([{"images": []}, {"videos": []}]) is None
-    got = VideoAwareVLMCollator._extract_videos([{"videos": ["f"]}, {"videos": []}])
-    assert got == [["f"], []]
+    assert VideoAwareVLMCollator._extract_videos([{"images": []}, {"videos": []}]) == (
+        None,
+        None,
+    )
+    videos, metadata = VideoAwareVLMCollator._extract_videos(
+        [{"videos": ["f"]}, {"videos": []}]
+    )
+    assert videos == [["f"], []]
+    assert metadata is None
+
+
+def test_extract_videos_unpacks_frames_and_metadata():
+    from trainers.vlm_collator import VideoAwareVLMCollator
+
+    videos, metadata = VideoAwareVLMCollator._extract_videos(
+        [
+            {
+                "videos": [
+                    {
+                        "frames": "clip-a",
+                        "video_metadata": {"fps": 24.0, "frames_indices": [0, 8]},
+                    }
+                ]
+            },
+            {"videos": []},
+        ]
+    )
+    assert videos == [["clip-a"], []]
+    assert metadata == [[{"fps": 24.0, "frames_indices": [0, 8]}], []]

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -298,7 +298,7 @@ class SFTVLMTrainer(BaseTrainer):
         data = self.config.data
         videos = []
         for s in sources:
-            frames = fetch_video(
+            frames, metadata = fetch_video(
                 s,
                 num_frames=data.video_num_frames,
                 fps=data.video_fps,
@@ -308,8 +308,9 @@ class SFTVLMTrainer(BaseTrainer):
                 s3_region=data.video_s3_region,
                 s3_endpoint_url=data.video_s3_endpoint_url,
                 backend=data.video_backend,
+                return_metadata=True,
             )
-            videos.append(frames)
+            videos.append({"frames": frames, "video_metadata": metadata})
         return videos
 
     @staticmethod

--- a/trainers/vlm_collator.py
+++ b/trainers/vlm_collator.py
@@ -12,7 +12,7 @@ When a batch carries no videos the base behavior is used verbatim, so the
 image-only path is completely unaffected.
 """
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
 
@@ -29,15 +29,26 @@ class _VideoInjectingProcessor:
     prompt/language-modeling call). In prompt-completion mode TRL invokes the
     processor a second time for the completion with ``text`` only -- that call
     must not receive the videos, or their tokens would be counted twice.
+
+    When ``video_metadata`` is present we also pass it through and set
+    ``do_sample_frames=False``. Frames were already sampled by
+    :func:`utils.video_utils.fetch_video`; resampling them against the original
+    clip length would either warn (missing fps) or crash (num_frames > tensor
+    length). The metadata's ``fps`` / ``frames_indices`` let Gemma stamp real
+    timestamps instead of defaulting to 24fps.
     """
 
-    def __init__(self, processor, videos):
+    def __init__(self, processor, videos, video_metadata=None):
         object.__setattr__(self, "_processor", processor)
         object.__setattr__(self, "_videos", videos)
+        object.__setattr__(self, "_video_metadata", video_metadata)
 
     def __call__(self, *args, **kwargs):
         if self._videos is not None and "images" in kwargs and "videos" not in kwargs:
             kwargs["videos"] = self._videos
+            if self._video_metadata is not None and "video_metadata" not in kwargs:
+                kwargs["video_metadata"] = self._video_metadata
+                kwargs.setdefault("do_sample_frames", False)
         return self._processor(*args, **kwargs)
 
     def __getattr__(self, name):
@@ -49,41 +60,62 @@ class VideoAwareVLMCollator(DataCollatorForVisionLanguageModeling):
 
     Examples may carry a ``"videos"`` key alongside ``"images"``: a list (one
     entry per video in the row) of frame arrays as produced by
-    :func:`utils.video_utils.fetch_video`. The corresponding messages are
-    expected to already contain ``{"type": "video"}`` content placeholders (the
-    trainer's transform emits structured content when a row has videos), so the
+    :func:`utils.video_utils.fetch_video`, or ``{"frames", "video_metadata"}``
+    dicts when metadata was requested. The corresponding messages are expected
+    to already contain ``{"type": "video"}`` content placeholders (the trainer's
+    transform emits structured content when a row has videos), so the
     processor's chat template renders the right video tokens.
     """
 
     @staticmethod
-    def _extract_videos(examples: List[dict]) -> Optional[List[Any]]:
+    def _unpack_video_item(item: Any) -> Tuple[Any, Optional[dict]]:
+        if isinstance(item, dict) and "frames" in item:
+            return item["frames"], item.get("video_metadata")
+        return item, None
+
+    @staticmethod
+    def _extract_videos(examples: List[dict]) -> Tuple[Optional[List[Any]], Optional[List[Any]]]:
         """Gather per-example video lists, or ``None`` when the batch has none.
 
         Mirrors TRL's image guard: transformers requires at least one video in
-        the batch or it errors, so an all-empty batch maps to ``None``.
+        the batch or it errors, so an all-empty batch maps to ``None``. When any
+        item carries metadata, a parallel nested metadata list is returned too.
         """
-        videos = [example.get("videos", []) or [] for example in examples]
+        videos = []
+        metadata = []
+        saw_metadata = False
+        for example in examples:
+            row_videos = []
+            row_metadata = []
+            for item in example.get("videos", []) or []:
+                frames, meta = VideoAwareVLMCollator._unpack_video_item(item)
+                row_videos.append(frames)
+                row_metadata.append(meta)
+                if meta is not None:
+                    saw_metadata = True
+            videos.append(row_videos)
+            metadata.append(row_metadata)
         if all(v == [] for v in videos):
-            return None
-        return videos
+            return None, None
+        return videos, (metadata if saw_metadata else None)
 
     def _collate_language_modeling(self, examples: List[dict]) -> dict:
-        videos = self._extract_videos(examples)
+        videos, video_metadata = self._extract_videos(examples)
         if videos is None:
             return super()._collate_language_modeling(examples)
         original = self.processor
-        self.processor = _VideoInjectingProcessor(original, videos)
+        self.processor = _VideoInjectingProcessor(original, videos, video_metadata)
         try:
             return super()._collate_language_modeling(examples)
         finally:
             self.processor = original
 
     def _collate_prompt_completion(self, examples: List[dict]) -> dict:
-        videos = self._extract_videos(examples)
+        videos, video_metadata = self._extract_videos(examples)
         if videos is None:
             return super()._collate_prompt_completion(examples)
         original = self.processor
-        self.processor = _VideoInjectingProcessor(original, videos)
+        self.processor = _VideoInjectingProcessor(original, videos, video_metadata)
         try:
             return super()._collate_prompt_completion(examples)
         finally:

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -19,6 +19,49 @@ from typing import Any, Optional
 from utils.image_utils import _cache_path, _fetch_url
 
 
+def as_video_metadata_dict(metadata):
+    """Convert transformers video metadata into a plain dict the processor accepts.
+
+    Gemma (and Qwen3-VL) need ``fps`` and ``frames_indices`` to stamp timestamps
+    into the prompt. ``load_video`` already returns this; we keep it instead of
+    dropping it and forcing the processor to guess ``fps=24``.
+    """
+    if metadata is None:
+        return None
+    if isinstance(metadata, dict):
+        data = dict(metadata)
+    else:
+        try:
+            data = {key: metadata[key] for key in metadata}
+        except Exception:
+            data = {
+                "total_num_frames": getattr(metadata, "total_num_frames", None),
+                "fps": getattr(metadata, "fps", None),
+                "width": getattr(metadata, "width", None),
+                "height": getattr(metadata, "height", None),
+                "duration": getattr(metadata, "duration", None),
+                "frames_indices": getattr(metadata, "frames_indices", None),
+            }
+    indices = data.get("frames_indices")
+    if indices is not None:
+        data["frames_indices"] = [int(i) for i in list(indices)]
+    fps = data.get("fps")
+    if fps is not None:
+        data["fps"] = float(fps)
+    total = data.get("total_num_frames")
+    if total is not None:
+        data["total_num_frames"] = int(total)
+    return data
+
+
+def _unpack_decode(decoded):
+    """Normalize ``_decode`` output to ``(frames, metadata_dict_or_none)``."""
+    if isinstance(decoded, tuple) and len(decoded) == 2:
+        frames, metadata = decoded
+        return frames, as_video_metadata_dict(metadata)
+    return decoded, None
+
+
 def _sample_kwargs(num_frames: Optional[int], fps: Optional[float]) -> dict:
     """Build the frame-sampling kwargs for ``load_video``.
 
@@ -37,8 +80,8 @@ def _decode(path: str, *, num_frames: Optional[int], fps: Optional[float], backe
     """Decode + sample frames from a local video file path."""
     from transformers.video_utils import load_video
 
-    frames, _metadata = load_video(path, backend=backend, **_sample_kwargs(num_frames, fps))
-    return frames
+    frames, metadata = load_video(path, backend=backend, **_sample_kwargs(num_frames, fps))
+    return frames, as_video_metadata_dict(metadata)
 
 
 def fetch_video(
@@ -52,6 +95,7 @@ def fetch_video(
     s3_region: Optional[str] = None,
     s3_endpoint_url: Optional[str] = None,
     backend: str = "pyav",
+    return_metadata: bool = False,
 ):
     """Resolve a video source into sampled frames the processor accepts.
 
@@ -61,10 +105,11 @@ def fetch_video(
       * a local file path string -> decoded from disk
       * a dict with a ``"url"``/``"path"``/``"video"`` key -> dispatched on the key
 
-    Frames are sampled with ``fps`` if set, else ``num_frames`` uniformly. The
-    return value is whatever ``transformers.video_utils.load_video`` produces
-    (a ``[T, H, W, C]`` array/tensor) -- pass it to a VLM processor as one entry
-    in ``videos=[...]``.
+    Frames are sampled with ``fps`` if set, else ``num_frames`` uniformly. By
+    default this returns the sampled frame array (``[T, H, W, C]``) for
+    ``videos=[...]``. With ``return_metadata=True`` it returns
+    ``(frames, metadata_dict)`` so Gemma/Qwen can stamp real timestamps instead
+    of guessing ``fps=24``.
 
     ``s3_region`` / ``s3_endpoint_url`` are only consulted for ``s3://`` sources;
     when unset, boto3 uses its default credential/region resolution chain.
@@ -73,6 +118,12 @@ def fetch_video(
         RuntimeError / OSError / TypeError: if the video cannot be fetched or
         decoded. Callers that want to skip bad rows should catch the exception.
     """
+    def _result(decoded):
+        frames, metadata = _unpack_decode(decoded)
+        if return_metadata:
+            return frames, metadata
+        return frames
+
     # HF-style dict wrappers, e.g. {"url": ...} / {"path": ...}.
     if isinstance(src, dict):
         for key in ("video", "path", "url"):
@@ -87,6 +138,7 @@ def fetch_video(
                     s3_region=s3_region,
                     s3_endpoint_url=s3_endpoint_url,
                     backend=backend,
+                    return_metadata=return_metadata,
                 )
         raise ValueError(f"Unsupported video dict with keys {list(src.keys())}")
 
@@ -116,13 +168,13 @@ def fetch_video(
                 with open(path, "wb") as f:
                     f.write(content)
             try:
-                return _decode(path, num_frames=num_frames, fps=fps, backend=backend)
+                return _result(_decode(path, num_frames=num_frames, fps=fps, backend=backend))
             except Exception:
                 # Corrupt cache entry; re-download once, then give up.
                 content = _download()
                 with open(path, "wb") as f:
                     f.write(content)
-                return _decode(path, num_frames=num_frames, fps=fps, backend=backend)
+                return _result(_decode(path, num_frames=num_frames, fps=fps, backend=backend))
 
         # No cache_dir: download to a temp file (load_video needs a path/URL, and
         # this keeps our retry + S3 handling instead of its plain httpx fetch).
@@ -131,7 +183,7 @@ def fetch_video(
         try:
             tmp.write(content)
             tmp.close()
-            return _decode(tmp.name, num_frames=num_frames, fps=fps, backend=backend)
+            return _result(_decode(tmp.name, num_frames=num_frames, fps=fps, backend=backend))
         finally:
             try:
                 os.unlink(tmp.name)
@@ -141,4 +193,4 @@ def fetch_video(
     # Treat as a local filesystem path.
     if not os.path.exists(src):
         raise FileNotFoundError(f"Video file not found: {src}")
-    return _decode(src, num_frames=num_frames, fps=fps, backend=backend)
+    return _result(_decode(src, num_frames=num_frames, fps=fps, backend=backend))


### PR DESCRIPTION
## Summary
- Keep `fps` / `frames_indices` from `load_video` instead of discarding them.
- Inject `video_metadata` into the VLM processor and set `do_sample_frames=False` so Gemma does not resample pre-sampled frames or default timestamps to 24fps.
- Apply the same metadata path to VLM inference.

## Test plan
- [ ] `python -m pytest tests/test_video_utils.py --import-mode=importlib --rootdir=tests -q`
- [ ] Retrain Gemma 4 `sft_vlm` with video columns and confirm the `Defaulting to fps=24` warning is gone.


Made with [Cursor](https://cursor.com)