### PR TITLE
chore(release): bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.4"
+version = "0.2.5"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to `0.2.5`.

The `v0.2.5` release tag points at `0f63983`, where `pyproject.toml` still said `0.2.4`. The publish workflow therefore built `fai_rl-0.2.4-py3-none-any.whl` and PyPI rejected it with `400 Bad Request` (that file already exists from the v0.2.4 release), so the video-metadata fix in #98 never shipped.

## Test plan
- [ ] Merge, then point the `v0.2.5` release at the new commit (delete + recreate the tag/release, or cut `v0.2.6`) so the workflow checks out a tree with the bumped version.
- [ ] Confirm the `Upload Python Package` run uploads `fai_rl-0.2.5-py3-none-any.whl`.
- [ ] `pip index versions FAI-RL` reports `0.2.5` as latest.


Made with [Cursor](https://cursor.com)