### PR TITLE
fix(vlm): load processor from peft base model

### DIFF
--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -227,7 +227,8 @@ class BaseTrainer(ABC):
         download only happens once per node per unique S3 URI.
 
         After this method returns, self.config.model.base_model_name points to
-        a local directory that AutoModelForCausalLM.from_pretrained() can load.
+        a local directory. Full HF checkpoints load from that path directly.
+        PEFT/LoRA adapter dirs are detected later by load_base_model_for_training.
         """
         import hashlib
         import tempfile
@@ -286,17 +287,13 @@ class BaseTrainer(ABC):
         rank switches to offline mode so the subsequent from_pretrained calls are
         pure cache reads (no Hub access left to race on).
 
-        No-op for single-process runs (local_rank == -1) and for local model
-        directories -- including an s3:// model already resolved to a temp dir by
-        _maybe_download_s3_model() -- where no Hub access happens.
+        No-op for single-process runs (local_rank == -1) and for local *full*
+        model directories. A local PEFT adapter dir still needs the Hub base
+        (adapter_config.base_model_name_or_path) warmed, because that is what
+        from_pretrained / AutoProcessor load next.
         """
-        model_name = self.config.model.base_model_name
-
-        # Single process: no peer ranks, nothing to coordinate.
-        if self.local_rank == -1:
-            return
-        # Local directory (incl. an already-downloaded S3 model): no Hub access.
-        if os.path.isdir(model_name):
+        model_name = self._hub_model_id_for_cache_warm()
+        if model_name is None:
             return
 
         import hashlib
@@ -335,6 +332,26 @@ class BaseTrainer(ABC):
         # from_pretrained calls don't re-hit (and race on) the Hub.
         os.environ["HF_HUB_OFFLINE"] = "1"
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
+    def _hub_model_id_for_cache_warm(self) -> Optional[str]:
+        """Hub id that peer ranks will from_pretrained, or None if no Hub warm is needed."""
+        if self.local_rank == -1:
+            return None
+
+        model_name = self.config.model.base_model_name
+        if not os.path.isdir(model_name):
+            return model_name
+
+        adapter_config_path = os.path.join(model_name, "adapter_config.json")
+        if not os.path.exists(adapter_config_path):
+            return None
+
+        from peft import PeftConfig
+
+        hub_id = PeftConfig.from_pretrained(model_name).base_model_name_or_path
+        if not hub_id or os.path.isdir(hub_id):
+            return None
+        return hub_id
 
     def setup_wandb(self):
         """Initialize Weights & Biases logging."""
@@ -631,6 +648,7 @@ class BaseTrainer(ABC):
 
         model_path = self.config.model.base_model_name
         self._peft_adapter_path = None
+        self._peft_base_model_path = None
 
         adapter_config_path = os.path.join(model_path, "adapter_config.json")
         if os.path.isdir(model_path) and os.path.exists(adapter_config_path):
@@ -640,6 +658,7 @@ class BaseTrainer(ABC):
                 "Detected PEFT checkpoint; loading base model from %s", base_model_path
             )
             self._peft_adapter_path = model_path
+            self._peft_base_model_path = base_model_path
             # ignore_mismatched_sizes is not needed when loading the base model clean.
             clean_kwargs = {k: v for k, v in model_kwargs.items() if k != "ignore_mismatched_sizes"}
             return self._auto_model_class.from_pretrained(base_model_path, **clean_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.5"
+version = "0.2.6"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/README.md
+++ b/recipes/training/README.md
@@ -204,7 +204,7 @@ model:
 
 **Continuing from a LoRA checkpoint:**
 
-The S3 callback saves LoRA adapter files (`adapter_config.json`, `adapter_model.safetensors`) when `save_only_model: true`. These can be loaded as `base_model_name` for the next training round — HuggingFace PEFT merges the adapter automatically on load.
+The S3 callback saves LoRA adapter files (`adapter_config.json`, `adapter_model.safetensors`) when `save_only_model: true`. These can be loaded as `base_model_name` for the next training round. Trainers detect `adapter_config.json`, load `base_model_name_or_path` from it, then resume the adapter (including `sft_vlm`, which loads AutoProcessor from that same Hub base — adapter dirs have no `config.json` / `model_type`).
 
 ## S3 Dataset Loading
 

--- a/tests/test_sft_vlm_trainer.py
+++ b/tests/test_sft_vlm_trainer.py
@@ -69,3 +69,67 @@ def test_normalize_dataset_keeps_valid_media_when_other_cells_are_empty():
         ["s3://bucket/video.mp4"],
         [],
     ]
+
+
+def test_setup_model_loads_processor_from_peft_base_not_adapter_dir(tmp_path, monkeypatch):
+    """LoRA checkpoints have no config.json/model_type. AutoProcessor must use the Hub base."""
+    import logging
+
+    adapter_dir = tmp_path / "checkpoint-614"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapter_config.json").write_text(
+        '{"base_model_name_or_path": "google/gemma-4-31B-it", "peft_type": "LORA"}'
+    )
+
+    captured = {}
+
+    def fake_from_pretrained(name, *args, **kwargs):
+        captured["processor_name"] = name
+        tokenizer = SimpleNamespace(pad_token="pad", eos_token="eos")
+        return SimpleNamespace(tokenizer=tokenizer)
+
+    monkeypatch.setattr(
+        "trainers.sft_vlm_trainer.AutoProcessor.from_pretrained", fake_from_pretrained
+    )
+
+    trainer = object.__new__(SFTVLMTrainer)
+    trainer.logger = logging.getLogger("test_peft_processor")
+    trainer.config = SimpleNamespace(
+        model=SimpleNamespace(
+            base_model_name=str(adapter_dir),
+            freeze_vision_tower=False,
+            use_lora=False,
+        )
+    )
+
+    def fake_load(_kwargs):
+        trainer._peft_adapter_path = str(adapter_dir)
+        trainer._peft_base_model_path = "google/gemma-4-31B-it"
+        return SimpleNamespace()
+
+    trainer.create_quantization_config = lambda: None
+    trainer.prepare_model_kwargs = lambda _q: {}
+    trainer.load_base_model_for_training = fake_load
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: model
+    trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
+
+    trainer.setup_model()
+
+    assert captured["processor_name"] == "google/gemma-4-31B-it"
+
+
+def test_hub_cache_warm_follows_peft_base_model(tmp_path):
+    adapter_dir = tmp_path / "checkpoint-614"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapter_config.json").write_text(
+        '{"base_model_name_or_path": "google/gemma-4-31B-it", "peft_type": "LORA"}'
+    )
+
+    trainer = object.__new__(SFTVLMTrainer)
+    trainer.local_rank = 0
+    trainer.config = SimpleNamespace(model=SimpleNamespace(base_model_name=str(adapter_dir)))
+
+    assert trainer._hub_model_id_for_cache_warm() == "google/gemma-4-31B-it"
+
+    trainer.local_rank = -1
+    assert trainer._hub_model_id_for_cache_warm() is None

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -81,7 +81,12 @@ class SFTVLMTrainer(BaseTrainer):
         # trainers we do NOT add a [PAD] token or resize embeddings -- doing so
         # corrupts a VLM's vision/token embedding alignment. VLM tokenizers
         # already define a pad token; fall back to eos only if missing.
-        self.processor = AutoProcessor.from_pretrained(self.config.model.base_model_name)
+        # PEFT/LoRA checkpoints have tokenizer shards but no config.json model_type.
+        # AutoProcessor must load the original Hub (or full) base, same as the model.
+        processor_name = (
+            getattr(self, "_peft_base_model_path", None) or self.config.model.base_model_name
+        )
+        self.processor = AutoProcessor.from_pretrained(processor_name)
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
         if getattr(tokenizer, "pad_token", None) is None and getattr(tokenizer, "eos_token", None):
             tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
sft_vlm resolved AutoProcessor from base_model_name, so continuing training from a LoRA checkpoint died in setup_model with "Unrecognized model in /tmp/fai-rl-model-<hash>. Should have a `model_type` key in its config.json". An adapter dir holds adapter_config.json plus tokenizer shards and no config.json, so only the model load followed base_model_name_or_path; the processor still pointed at the adapter dir.

load_base_model_for_training now records the resolved base as _peft_base_model_path and sft_vlm loads the processor from it, matching how inference already handles PEFT checkpoints. Hub cache warming follows the same base so multi-rank jobs still pre-fetch on local rank 0 before TRANSFORMERS_OFFLINE is set.