### PR TITLE
fix(training): load tokenizer from peft base model

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,10 +461,26 @@ limitations under the License.
 <details>
 <summary>Publishing a New Release</summary>
 
-1. **Update version** in `pyproject.toml`:
+Releases must be published from the repository's
+[GitHub Releases page](https://github.com/Roblox/FAI-RL/releases). Publishing
+a GitHub release triggers `.github/workflows/python-publish.yml`, which builds
+the distributions and uploads them to PyPI.
+
+1. **Update and merge the version** in `pyproject.toml`:
 ```toml
 [project]
 name = "FAI-RL"
 version = "X.Y.Z"  # Increment version
 ```
+
+2. Open [GitHub Releases](https://github.com/Roblox/FAI-RL/releases), select
+   **Draft a new release**, and create tag `vX.Y.Z` from the merged `main`
+   branch.
+3. Use `vX.Y.Z` as the release title, add concise release notes, and select
+   **Publish release**.
+4. Verify the **Upload Python Package** workflow succeeds and that version
+   `X.Y.Z` is available from PyPI before consumers pin or deploy it.
+
+The tag and `pyproject.toml` version must match. PyPI versions are immutable,
+so do not reuse a version after it has been published.
 </details>

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -491,6 +491,19 @@ class BaseTrainer(ABC):
         
         return model_kwargs
 
+    def resolved_pretrained_name(self) -> str:
+        """Return the base model path for tokenizer and reference-model loading.
+
+        PEFT adapter directories intentionally have no model ``config.json``.
+        After adapter-aware model loading, ``_peft_base_model_path`` points to
+        the original Hub or full-model base. Non-PEFT loads fall back to the
+        configured model path.
+        """
+        return (
+            getattr(self, "_peft_base_model_path", None)
+            or self.config.model.base_model_name
+        )
+
     def setup_tokenizer_with_model(self, model, model_name: Optional[str] = None):
         """Setup tokenizer and resize model embeddings.
         
@@ -503,10 +516,7 @@ class BaseTrainer(ABC):
             The configured tokenizer.
         """
         if model_name is None:
-            model_name = (
-                getattr(self, "_peft_base_model_path", None)
-                or self.config.model.base_model_name
-            )
+            model_name = self.resolved_pretrained_name()
             
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -496,13 +496,17 @@ class BaseTrainer(ABC):
         
         Args:
             model: The model to resize embeddings for.
-            model_name: Optional model name for loading tokenizer. Defaults to config.model.base_model_name.
+            model_name: Optional model name for loading tokenizer. Defaults to
+                the resolved PEFT base model, then config.model.base_model_name.
             
         Returns:
             The configured tokenizer.
         """
         if model_name is None:
-            model_name = self.config.model.base_model_name
+            model_name = (
+                getattr(self, "_peft_base_model_path", None)
+                or self.config.model.base_model_name
+            )
             
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.6"
+version = "0.2.7"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/README.md
+++ b/recipes/training/README.md
@@ -204,7 +204,7 @@ model:
 
 **Continuing from a LoRA checkpoint:**
 
-The S3 callback saves LoRA adapter files (`adapter_config.json`, `adapter_model.safetensors`) when `save_only_model: true`. These can be loaded as `base_model_name` for the next training round. Trainers detect `adapter_config.json`, load `base_model_name_or_path` from it, then resume the adapter (including `sft_vlm`, which loads AutoProcessor from that same Hub base — adapter dirs have no `config.json` / `model_type`).
+The S3 callback saves LoRA adapter files (`adapter_config.json`, `adapter_model.safetensors`) when `save_only_model: true`. These can be loaded as `base_model_name` for the next training round. Trainers detect `adapter_config.json`, load `base_model_name_or_path` from it, then resume the adapter. Tokenizer, processor, and DPO reference-model loads follow that same Hub or full-model base because adapter directories have no model `config.json` / `model_type`.
 
 ## S3 Dataset Loading
 

--- a/tests/test_peft_checkpoint_resume.py
+++ b/tests/test_peft_checkpoint_resume.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from core.trainer_base import BaseTrainer
+from trainers.dpo_trainer import DPOTrainer
 
 
 class ConcreteTrainer(BaseTrainer):
@@ -85,3 +87,68 @@ def test_explicit_tokenizer_model_name_overrides_peft_base(monkeypatch):
     trainer.setup_tokenizer_with_model(model, model_name="explicit/tokenizer")
 
     assert captured["tokenizer_name"] == "explicit/tokenizer"
+
+
+def test_resolved_pretrained_name_falls_back_for_full_model():
+    trainer = object.__new__(ConcreteTrainer)
+    trainer.config = SimpleNamespace(model=SimpleNamespace(base_model_name="catalog/model"))
+    trainer._peft_base_model_path = None
+
+    assert trainer.resolved_pretrained_name() == "catalog/model"
+
+
+def test_dpo_reference_model_loads_from_peft_base(monkeypatch):
+    captured = {}
+
+    class FakeTokenizer:
+        pad_token = "pad"
+        eos_token = "eos"
+        padding_side = "right"
+
+        def add_special_tokens(self, _tokens):
+            return 0
+
+        def __len__(self):
+            return 128
+
+    class FakeModel:
+        def resize_token_embeddings(self, _size):
+            pass
+
+    monkeypatch.setattr(
+        "core.trainer_base.AutoTokenizer.from_pretrained",
+        lambda name, *args, **kwargs: FakeTokenizer(),
+    )
+
+    def fake_model_from_pretrained(name, *args, **kwargs):
+        captured["reference_model_name"] = name
+        return FakeModel()
+
+    monkeypatch.setattr(
+        "trainers.dpo_trainer.AutoModelForCausalLM.from_pretrained",
+        fake_model_from_pretrained,
+    )
+
+    trainer = object.__new__(DPOTrainer)
+    trainer.logger = logging.getLogger("test_peft_dpo_reference")
+    trainer.config = SimpleNamespace(
+        model=SimpleNamespace(
+            base_model_name="/tmp/fai-rl-model-adapter",
+            use_lora=False,
+        )
+    )
+
+    def fake_load(_kwargs):
+        trainer._peft_adapter_path = "/tmp/fai-rl-model-adapter"
+        trainer._peft_base_model_path = "Qwen/Qwen3.8-27B"
+        return FakeModel()
+
+    trainer.create_quantization_config = lambda: None
+    trainer.prepare_model_kwargs = lambda _quantization: {}
+    trainer.load_base_model_for_training = fake_load
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: model
+    trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
+
+    trainer.setup_model()
+
+    assert captured["reference_model_name"] == "Qwen/Qwen3.8-27B"

--- a/tests/test_peft_checkpoint_resume.py
+++ b/tests/test_peft_checkpoint_resume.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Ensure the repo root is importable so `core.*` resolves.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.trainer_base import BaseTrainer
+
+
+class ConcreteTrainer(BaseTrainer):
+    def setup_model(self):
+        pass
+
+    def setup_data(self):
+        pass
+
+    def setup_trainer(self):
+        pass
+
+    def train(self):
+        pass
+
+
+def test_tokenizer_loads_from_peft_base_not_adapter_dir(monkeypatch):
+    """Adapter checkpoints have no config.json, so tokenizers must use the Hub base."""
+    captured = {}
+
+    class FakeTokenizer:
+        pad_token = "pad"
+        eos_token = "eos"
+        padding_side = "right"
+
+        def add_special_tokens(self, _tokens):
+            return 0
+
+        def __len__(self):
+            return 128
+
+    def fake_from_pretrained(name, *args, **kwargs):
+        captured["tokenizer_name"] = name
+        return FakeTokenizer()
+
+    monkeypatch.setattr("core.trainer_base.AutoTokenizer.from_pretrained", fake_from_pretrained)
+
+    trainer = object.__new__(ConcreteTrainer)
+    trainer.config = SimpleNamespace(
+        model=SimpleNamespace(base_model_name="/tmp/fai-rl-model-adapter")
+    )
+    trainer._peft_base_model_path = "Qwen/Qwen3.8-27B"
+    model = SimpleNamespace(resize_token_embeddings=lambda _size: None)
+
+    trainer.setup_tokenizer_with_model(model)
+
+    assert captured["tokenizer_name"] == "Qwen/Qwen3.8-27B"
+
+
+def test_explicit_tokenizer_model_name_overrides_peft_base(monkeypatch):
+    captured = {}
+
+    class FakeTokenizer:
+        pad_token = "pad"
+        eos_token = "eos"
+        padding_side = "right"
+
+        def add_special_tokens(self, _tokens):
+            return 0
+
+        def __len__(self):
+            return 128
+
+    def fake_from_pretrained(name, *args, **kwargs):
+        captured["tokenizer_name"] = name
+        return FakeTokenizer()
+
+    monkeypatch.setattr("core.trainer_base.AutoTokenizer.from_pretrained", fake_from_pretrained)
+
+    trainer = object.__new__(ConcreteTrainer)
+    trainer.config = SimpleNamespace(model=SimpleNamespace(base_model_name="catalog/model"))
+    trainer._peft_base_model_path = "adapter/base"
+    model = SimpleNamespace(resize_token_embeddings=lambda _size: None)
+
+    trainer.setup_tokenizer_with_model(model, model_name="explicit/tokenizer")
+
+    assert captured["tokenizer_name"] == "explicit/tokenizer"

--- a/trainers/dpo_trainer.py
+++ b/trainers/dpo_trainer.py
@@ -47,7 +47,7 @@ class DPOTrainer(BaseTrainer):
         if not getattr(self.config.model, 'use_lora', False):
             self.logger.info("Loading separate reference model (no LoRA)")
             self.ref_model = AutoModelForCausalLM.from_pretrained(
-                self.config.model.base_model_name,
+                self.resolved_pretrained_name(),
                 **model_kwargs
             )
         else:


### PR DESCRIPTION
## Summary
- resolve text tokenizers from the original Hugging Face base when continuing from adapter-only PEFT checkpoints
- share PEFT-aware path resolution with DPO's separate non-LoRA reference model
- preserve explicit tokenizer overrides and full-model behavior
- document continuation behavior, add regression coverage, and bump FAI-RL to 0.2.7

## Test plan
- [x] `uv run --no-project --python 3.11 --with pytest --with trl --with datasets --with boto3 --with pillow --with av python -m pytest -q` (45 passed)
- [ ] publish v0.2.7 and retry the failed DPO continuation job