### PR TITLE
fix(s3): reject incomplete model downloads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Roblox/fairl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.7"
+version = "0.2.8"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_s3_utils_region.py
+++ b/tests/test_s3_utils_region.py
@@ -9,7 +9,8 @@ upload to a us-east-1 bucket from a us-east-2 pod inherits us-east-2 and
 import subprocess
 import sys
 from pathlib import Path
-from unittest import mock
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -78,16 +79,62 @@ def test_upload_file_region_overrides_ambient_aws_region(tmp_path, monkeypatch):
 def test_download_region_overrides_ambient_aws_region(tmp_path, monkeypatch):
     monkeypatch.setenv("AWS_REGION", "us-east-2")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+    out = tmp_path / "out"
 
-    captured = _capture_s5cmd_env(
-        monkeypatch,
-        lambda: s3_utils.download_directory_from_s3(
-            "s3://ml-platform-generic/prefix",
-            str(tmp_path / "out"),
-            region="us-east-1",
-            downloader="s5cmd",
-        ),
+    captured = {}
+
+    def fake_run(argv, *args, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env")
+        (out / "checkpoint.bin").write_text("weights")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(s3_utils.shutil, "which", lambda _name: "/usr/bin/s5cmd")
+    monkeypatch.setattr(s3_utils.subprocess, "run", fake_run)
+
+    s3_utils.download_directory_from_s3(
+        "s3://ml-platform-generic/prefix",
+        str(out),
+        region="us-east-1",
+        downloader="s5cmd",
     )
 
     assert captured["env"]["AWS_REGION"] == "us-east-1"
     assert captured["env"]["AWS_DEFAULT_REGION"] == "us-east-1"
+
+
+def test_download_rejects_s5cmd_error_with_zero_exit(tmp_path, monkeypatch):
+    monkeypatch.setattr(s3_utils.shutil, "which", lambda _name: "/usr/bin/s5cmd")
+    monkeypatch.setattr(
+        s3_utils.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            ["s5cmd"],
+            0,
+            stdout="",
+            stderr="ERROR BucketRegionError: bucket is in 'us-east-1'",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="BucketRegionError"):
+        s3_utils.download_directory_from_s3(
+            "s3://ml-platform-generic/prefix",
+            str(tmp_path / "out"),
+            downloader="s5cmd",
+        )
+
+
+def test_download_rejects_empty_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(s3_utils.shutil, "which", lambda _name: "/usr/bin/s5cmd")
+    monkeypatch.setattr(
+        s3_utils.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(["s5cmd"], 0, stdout="", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError, match="downloaded no files"):
+        s3_utils.download_directory_from_s3(
+            "s3://ml-platform-generic/prefix",
+            str(tmp_path / "out"),
+            downloader="s5cmd",
+        )

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -306,9 +306,13 @@ def download_directory_from_s3(
             env["AWS_REGION"] = region
             env["AWS_DEFAULT_REGION"] = region
         result = subprocess.run(argv, env=env, capture_output=True, text=True)
-        if result.returncode != 0:
+        output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+        # s5cmd 2.3.0 `sync` can print an ERROR (notably BucketRegionError) while
+        # returning zero. Treat its structured error output as a failure too.
+        has_error = any(line.lstrip().startswith("ERROR ") for line in output.splitlines())
+        if result.returncode != 0 or has_error:
             raise RuntimeError(
-                f"s5cmd download failed (exit {result.returncode}): {result.stderr.strip()}"
+                f"s5cmd download failed (exit {result.returncode}): {output.strip()}"
             )
     else:
         client = _get_s3_client(region, endpoint_url)
@@ -325,6 +329,10 @@ def download_directory_from_s3(
                 client.download_file(bucket, key, local_file)
                 total += 1
         logger.info("Downloaded %d files from s3://%s/%s", total, bucket, prefix)
+
+    downloaded_files = sum(1 for path in Path(local_dir).rglob("*") if path.is_file())
+    if downloaded_files == 0:
+        raise RuntimeError(f"S3 download from s3://{bucket}/{prefix} downloaded no files")
 
     logger.info("Download complete: s3://%s/%s -> %s", bucket, prefix, local_dir)
 


### PR DESCRIPTION
Detect s5cmd errors that return a zero exit status and prevent empty model caches from being marked complete.