### PR TITLE
feat(rewards): support API-scored GRPO and GSPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ FAI-RL provides pre-configured recipes and has been validated with the following
 **Custom Reward Services:**
 - GRPO and GSPO reward calculation uses a configured HTTP API in production
 - Prompts, completions, and dataset context are scored outside the training code
-- Authentication, retries, timeouts, headers, and response fields are recipe-driven
+- Retries, timeouts, headers, and response fields are recipe-driven
 - FAI-RL development tests can import a local Python reward callable from YAML
 
 **Dataset Templates:**

--- a/README.md
+++ b/README.md
@@ -230,9 +230,10 @@ FAI-RL provides pre-configured recipes and has been validated with the following
 ### 🔧 Extensible Architecture
 
 **Custom Reward Services:**
-- GRPO and GSPO reward calculation is configured as an HTTP API
+- GRPO and GSPO reward calculation uses a configured HTTP API in production
 - Prompts, completions, and dataset context are scored outside the training code
 - Authentication, retries, timeouts, headers, and response fields are recipe-driven
+- FAI-RL development tests can import a local Python reward callable from YAML
 
 **Dataset Templates:**
 - `GSM8KTemplate` - Math problem formatting with chain-of-thought

--- a/README.md
+++ b/README.md
@@ -229,10 +229,10 @@ FAI-RL provides pre-configured recipes and has been validated with the following
 
 ### 🔧 Extensible Architecture
 
-**Custom Reward Functions:**
-- `exact_match_reward_func` - Accuracy-based rewards for verifiable tasks
-- `structured_xml_reward_func` - Format-based rewards for structured outputs
-- Easy to add your custom reward function
+**Custom Reward Services:**
+- GRPO and GSPO reward calculation is configured as an HTTP API
+- Prompts, completions, and dataset context are scored outside the training code
+- Authentication, retries, timeouts, headers, and response fields are recipe-driven
 
 **Dataset Templates:**
 - `GSM8KTemplate` - Math problem formatting with chain-of-thought

--- a/core/config.py
+++ b/core/config.py
@@ -302,6 +302,45 @@ class TrainingConfig:
 
 
 @dataclass
+class RewardAPIConfig:
+    """HTTP reward service configuration for GRPO and GSPO."""
+    endpoint: str
+    api_key: Optional[str] = None
+    auth_header: str = "Authorization"
+    auth_scheme: str = "Bearer"
+    headers: Dict[str, str] = field(default_factory=dict)
+    extra_body: Dict[str, Any] = field(default_factory=dict)
+    response_field: str = "rewards"
+    timeout_seconds: float = 30.0
+    max_retries: int = 2
+    retry_backoff_seconds: float = 1.0
+    verify_ssl: bool = True
+
+    def __post_init__(self):
+        if not self.endpoint:
+            raise ValueError("reward_api.endpoint is required")
+        validate_api_config(self)
+        if self.timeout_seconds <= 0:
+            raise ValueError("reward_api.timeout_seconds must be greater than zero")
+        if self.max_retries < 0:
+            raise ValueError("reward_api.max_retries cannot be negative")
+        if self.retry_backoff_seconds < 0:
+            raise ValueError("reward_api.retry_backoff_seconds cannot be negative")
+
+    @property
+    def api_endpoint(self) -> str:
+        """Compatibility alias for the shared API configuration validator."""
+        return self.endpoint
+
+    def to_dict(self) -> Dict[str, Any]:
+        values = {
+            key: value for key, value in self.__dict__.items() if not key.startswith('_')
+        }
+        values["api_key"] = "***" if self.api_key else None
+        return values
+
+
+@dataclass
 class WandbConfig:
     """Configuration for Weights & Biases logging."""
     enabled: bool = True
@@ -503,6 +542,7 @@ class ExperimentConfig:
     training: TrainingConfig
     wandb: WandbConfig
     s3: S3Config = field(default_factory=S3Config)
+    reward_api: Optional[RewardAPIConfig] = None
     
     @classmethod
     def from_yaml(cls, config_path: str) -> 'ExperimentConfig':
@@ -523,6 +563,11 @@ class ExperimentConfig:
             training=TrainingConfig(**config_dict['training']),
             wandb=WandbConfig(**config_dict.get('wandb', {})),
             s3=S3Config(**config_dict.get('s3', {})),
+            reward_api=(
+                RewardAPIConfig(**config_dict['reward_api'])
+                if config_dict.get('reward_api')
+                else None
+            ),
         )
     
     @classmethod
@@ -559,6 +604,7 @@ class ExperimentConfig:
             'training': self.training.to_dict(),
             'wandb': self.wandb.to_dict(),
             's3': self.s3.to_dict(),
+            'reward_api': self.reward_api.to_dict() if self.reward_api else None,
         }
         
         with open(output_path, 'w') as f:

--- a/core/config.py
+++ b/core/config.py
@@ -343,7 +343,7 @@ class RewardAPIConfig:
 
 @dataclass
 class LocalRewardFunctionConfig:
-    """Local Python reward callable configuration for FAI-RL testing."""
+    """Trusted local Python reward callable configuration for FAI-RL."""
     function: str
     kwargs: Dict[str, Any] = field(default_factory=dict)
 

--- a/core/config.py
+++ b/core/config.py
@@ -341,6 +341,32 @@ class RewardAPIConfig:
 
 
 @dataclass
+class LocalRewardFunctionConfig:
+    """Local Python reward callable configuration for FAI-RL testing."""
+    function: str
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        module_name, separator, function_name = self.function.partition(":")
+        if not separator or not module_name or not function_name:
+            raise ValueError(
+                "local_reward_function.function must use 'module.path:function_name'"
+            )
+        reserved = {"prompts", "completions", "logger"}
+        conflicts = reserved.intersection(self.kwargs)
+        if conflicts:
+            raise ValueError(
+                "local_reward_function.kwargs cannot override reserved arguments: "
+                f"{', '.join(sorted(conflicts))}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            key: value for key, value in self.__dict__.items() if not key.startswith('_')
+        }
+
+
+@dataclass
 class WandbConfig:
     """Configuration for Weights & Biases logging."""
     enabled: bool = True
@@ -543,6 +569,7 @@ class ExperimentConfig:
     wandb: WandbConfig
     s3: S3Config = field(default_factory=S3Config)
     reward_api: Optional[RewardAPIConfig] = None
+    local_reward_function: Optional[LocalRewardFunctionConfig] = None
     
     @classmethod
     def from_yaml(cls, config_path: str) -> 'ExperimentConfig':
@@ -566,6 +593,11 @@ class ExperimentConfig:
             reward_api=(
                 RewardAPIConfig(**config_dict['reward_api'])
                 if config_dict.get('reward_api')
+                else None
+            ),
+            local_reward_function=(
+                LocalRewardFunctionConfig(**config_dict['local_reward_function'])
+                if config_dict.get('local_reward_function')
                 else None
             ),
         )
@@ -605,6 +637,11 @@ class ExperimentConfig:
             'wandb': self.wandb.to_dict(),
             's3': self.s3.to_dict(),
             'reward_api': self.reward_api.to_dict() if self.reward_api else None,
+            'local_reward_function': (
+                self.local_reward_function.to_dict()
+                if self.local_reward_function
+                else None
+            ),
         }
         
         with open(output_path, 'w') as f:

--- a/core/config.py
+++ b/core/config.py
@@ -305,9 +305,6 @@ class TrainingConfig:
 class RewardAPIConfig:
     """HTTP reward service configuration for GRPO and GSPO."""
     endpoint: str
-    api_key: Optional[str] = None
-    auth_header: str = "Authorization"
-    auth_scheme: str = "Bearer"
     headers: Dict[str, str] = field(default_factory=dict)
     extra_body: Dict[str, Any] = field(default_factory=dict)
     response_field: str = "rewards"
@@ -320,6 +317,10 @@ class RewardAPIConfig:
         if not self.endpoint:
             raise ValueError("reward_api.endpoint is required")
         validate_api_config(self)
+        if self.headers and not self.endpoint.startswith("https://"):
+            raise ValueError(
+                "reward_api.endpoint must use https when headers are configured"
+            )
         if self.timeout_seconds <= 0:
             raise ValueError("reward_api.timeout_seconds must be greater than zero")
         if self.max_retries < 0:
@@ -336,7 +337,7 @@ class RewardAPIConfig:
         values = {
             key: value for key, value in self.__dict__.items() if not key.startswith('_')
         }
-        values["api_key"] = "***" if self.api_key else None
+        values["headers"] = {key: "***" for key in self.headers}
         return values
 
 

--- a/data/grpo/example_local_reward.jsonl
+++ b/data/grpo/example_local_reward.jsonl
@@ -1,0 +1,4 @@
+{"prompt":"What is 2 + 2? Return the final answer inside <answer> tags.","answer":"4"}
+{"prompt":"What is 3 multiplied by 5? Return the final answer inside <answer> tags.","answer":"15"}
+{"prompt":"What is 10 minus 7? Return the final answer inside <answer> tags.","answer":"3"}
+{"prompt":"What is half of 16? Return the final answer inside <answer> tags.","answer":"8"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.8"
+version = "0.2.9"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/recipes/training/grpo/llama3_3B_full.yaml
+++ b/recipes/training/grpo/llama3_3B_full.yaml
@@ -67,6 +67,12 @@ training:
   # GRPO-specific parameters
   num_generations: 8                                    # Group size for sequence grouping
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring
 wandb:

--- a/recipes/training/grpo/llama3_3B_local_file.yaml
+++ b/recipes/training/grpo/llama3_3B_local_file.yaml
@@ -75,6 +75,12 @@ training:
   # GRPO-specific parameters
   num_generations: 8                                    # Group size for sequence grouping
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring
 wandb:

--- a/recipes/training/grpo/llama3_3B_local_reward.yaml
+++ b/recipes/training/grpo/llama3_3B_local_reward.yaml
@@ -1,0 +1,87 @@
+# FAI-RL-only GRPO smoke test using a local Python reward function.
+# Run from the repository root:
+#   fai-rl-train --recipe recipes/training/grpo/llama3_3B_local_reward.yaml --num-gpus 1
+
+model:
+  base_model_name: "meta-llama/Llama-3.2-3B-Instruct"
+  torch_dtype: "bfloat16"
+  low_cpu_mem_usage: true
+  load_in_8bit: false
+  load_in_4bit: false
+  use_flash_attention: false
+
+  use_lora: true
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules:
+    - q_proj
+    - v_proj
+    - k_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
+  lora_bias: "none"
+
+data:
+  datasets:
+    - name: "data/grpo/example_local_reward.jsonl"
+      prompt_column: "prompt"
+      answer_column: "answer"
+  max_length: 1024
+  max_prompt_length: 512
+  remove_unused_columns: false
+
+training:
+  algorithm: "grpo"
+  output_dir: "models/llama3-3B-grpo-local-reward-smoke-test"
+
+  # Keep this recipe short: one optimizer step on one GPU.
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 2
+  learning_rate: 1.0e-4
+  num_train_epochs: 1
+  max_steps: 1
+  warmup_steps: 0
+
+  logging_steps: 1
+  save_steps: 100
+  eval_steps: 100
+
+  bf16: true
+  fp16: false
+  gradient_checkpointing: true
+  dataloader_num_workers: 0
+  dataloader_pin_memory: false
+  dataloader_drop_last: true
+  save_only_model: true
+  prediction_loss_only: true
+
+  # Must divide the effective single-GPU batch size (1 × 2).
+  num_generations: 2
+
+# Local imports execute trusted Python code in every training worker.
+# This option is intended only for FAI-RL development and testing.
+local_reward_function:
+  function: "trainers.rewards.accuracy_rewards:exact_match_reward_func"
+  kwargs: {}
+
+wandb:
+  enabled: false
+  project: "fai-rl-local-tests"
+  entity: null
+  name: "llama3-3B-grpo-local-reward-smoke-test"
+  tags: ["GRPO", "local-reward", "smoke-test"]
+  api_key: null
+  base_url: "https://api.wandb.ai"
+
+s3:
+  enabled: false
+  bucket: ""
+  prefix: ""
+  region: null
+  endpoint_url: null
+  upload_checkpoints: false
+  upload_final_model: false
+  delete_local_after_upload: false

--- a/recipes/training/grpo/llama3_3B_lora.yaml
+++ b/recipes/training/grpo/llama3_3B_lora.yaml
@@ -81,6 +81,11 @@ training:
   # GRPO-specific parameters
   num_generations: 8                                    # Group size for sequence grouping
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"               # POST endpoint implementing the reward API contract
+  timeout_seconds: 30
+  max_retries: 2
 
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring

--- a/recipes/training/grpo/llama3_3B_s3_file.yaml
+++ b/recipes/training/grpo/llama3_3B_s3_file.yaml
@@ -77,6 +77,12 @@ training:
   # GRPO-specific parameters
   num_generations: 8                                    # Group size for sequence grouping
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring
 wandb:

--- a/recipes/training/gspo/llama3_3B_full.yaml
+++ b/recipes/training/gspo/llama3_3B_full.yaml
@@ -74,6 +74,12 @@ training:
   epsilon_high: 4e-4                                    # Policy exploration parameter (upper bound)
   steps_per_generation: 4                               # Minibatch partitioning for rollout data
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring

--- a/recipes/training/gspo/llama3_3B_local_file.yaml
+++ b/recipes/training/gspo/llama3_3B_local_file.yaml
@@ -80,6 +80,12 @@ training:
   steps_per_generation: 4                               # Gradient update minibatches per rollout batch
   importance_sampling_level: "sequence"                 # GSPO uses sequence-level importance sampling
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring
 wandb:

--- a/recipes/training/gspo/llama3_3B_lora.yaml
+++ b/recipes/training/gspo/llama3_3B_lora.yaml
@@ -88,6 +88,12 @@ training:
   epsilon_high: 4e-4                                    # Policy exploration parameter (upper bound)
   steps_per_generation: 4                               # Minibatch partitioning for rollout data
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"               # POST endpoint implementing the reward API contract
+  timeout_seconds: 30
+  max_retries: 2
+
 
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring

--- a/recipes/training/gspo/llama3_3B_s3_file.yaml
+++ b/recipes/training/gspo/llama3_3B_s3_file.yaml
@@ -82,6 +82,12 @@ training:
   steps_per_generation: 4                               # Gradient update minibatches per rollout batch
   importance_sampling_level: "sequence"                 # GSPO uses sequence-level importance sampling
 
+# External reward scorer (required for GRPO/GSPO)
+reward_api:
+  endpoint: "https://<YOUR_API_ENDPOINT>"
+  timeout_seconds: 30
+  max_retries: 2
+
 # Weights & Biases Integration
 # Optional experiment tracking and monitoring
 wandb:

--- a/tests/test_api_reward.py
+++ b/tests/test_api_reward.py
@@ -109,10 +109,22 @@ def test_api_reward_logs_safe_batch_summary(monkeypatch, caplog):
     assert "sensitive-completion" not in caplog.text
 
 
-def test_reward_api_redacts_inline_key():
+def test_reward_api_redacts_configured_headers():
     config = RewardAPIConfig(
         endpoint="https://reward.example/score",
-        api_key="secret",
+        headers={"X-Tenant": "customer-care"},
     )
 
-    assert config.to_dict()["api_key"] == "***"
+    serialized = config.to_dict()
+    assert serialized["headers"] == {"X-Tenant": "***"}
+    assert "api_key" not in serialized
+    assert "auth_header" not in serialized
+    assert "auth_scheme" not in serialized
+
+
+def test_reward_api_requires_https_for_headers():
+    with pytest.raises(ValueError, match="must use https"):
+        RewardAPIConfig(
+            endpoint="http://reward.example/score",
+            headers={"X-Tenant": "customer-care"},
+        )

--- a/tests/test_api_reward.py
+++ b/tests/test_api_reward.py
@@ -38,6 +38,7 @@ def test_api_reward_sends_context_without_requiring_auth(monkeypatch):
     reward = APIRewardFunction(
         RewardAPIConfig(endpoint="https://reward.example/score")
     )
+    assert reward.__name__ == "api_reward"
 
     scores = reward(
         ["prompt-a", "prompt-b"],

--- a/tests/test_api_reward.py
+++ b/tests/test_api_reward.py
@@ -1,0 +1,98 @@
+"""Tests for the HTTP-backed GRPO/GSPO reward function."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.config import RewardAPIConfig
+from trainers.rewards.api_reward import APIRewardFunction
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.body
+
+
+def test_api_reward_sends_context_without_requiring_auth(monkeypatch):
+    captured = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return _Response({"rewards": [1, 0.25]})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    reward = APIRewardFunction(
+        RewardAPIConfig(endpoint="https://reward.example/score")
+    )
+
+    scores = reward(
+        ["prompt-a", "prompt-b"],
+        ["completion-a", "completion-b"],
+        answer=["a", "b"],
+    )
+
+    assert scores == [1.0, 0.25]
+    assert captured["url"] == "https://reward.example/score"
+    assert "Authorization" not in captured["headers"]
+    assert captured["json"]["context"] == {"answer": ["a", "b"]}
+
+
+def test_api_reward_rejects_wrong_score_count(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response({"rewards": [1.0]}),
+    )
+    reward = APIRewardFunction(
+        RewardAPIConfig(
+            endpoint="https://reward.example/score",
+            max_retries=0,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="1 rewards for 2 completions"):
+        reward(["a", "b"], ["x", "y"])
+
+
+def test_api_reward_retries_transient_failure(monkeypatch):
+    calls = []
+
+    def fake_post(*_args, **_kwargs):
+        calls.append(None)
+        if len(calls) == 1:
+            raise requests.ConnectionError("temporary")
+        return _Response({"rewards": [0.5]})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr("trainers.rewards.api_reward.time.sleep", lambda _delay: None)
+    reward = APIRewardFunction(
+        RewardAPIConfig(
+            endpoint="https://reward.example/score",
+            max_retries=1,
+        )
+    )
+
+    assert reward(["a"], ["x"]) == [0.5]
+    assert len(calls) == 2
+
+
+def test_reward_api_redacts_inline_key():
+    config = RewardAPIConfig(
+        endpoint="https://reward.example/score",
+        api_key="secret",
+    )
+
+    assert config.to_dict()["api_key"] == "***"

--- a/tests/test_api_reward.py
+++ b/tests/test_api_reward.py
@@ -1,5 +1,6 @@
 """Tests for the HTTP-backed GRPO/GSPO reward function."""
 
+import logging
 import sys
 from pathlib import Path
 
@@ -87,6 +88,25 @@ def test_api_reward_retries_transient_failure(monkeypatch):
 
     assert reward(["a"], ["x"]) == [0.5]
     assert len(calls) == 2
+
+
+def test_api_reward_logs_safe_batch_summary(monkeypatch, caplog):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response({"rewards": [0.25, 0.75]}),
+    )
+    reward = APIRewardFunction(
+        RewardAPIConfig(endpoint="https://reward.example/score")
+    )
+
+    with caplog.at_level(logging.INFO, logger="trainers.rewards.api_reward"):
+        reward(["sensitive-prompt"], ["sensitive-completion", "other"])
+
+    assert "Reward API scored 2 completions" in caplog.text
+    assert "mean=0.5000" in caplog.text
+    assert "sensitive-prompt" not in caplog.text
+    assert "sensitive-completion" not in caplog.text
 
 
 def test_reward_api_redacts_inline_key():

--- a/tests/test_local_reward.py
+++ b/tests/test_local_reward.py
@@ -23,6 +23,8 @@ def test_local_reward_loads_configured_callable(caplog):
         )
     )
 
+    assert reward.__name__ == "exact_match_reward_func"
+
     with caplog.at_level(logging.INFO, logger="trainers.rewards.local_reward"):
         scores = reward(
             ["sensitive-prompt", "other-prompt"],

--- a/tests/test_local_reward.py
+++ b/tests/test_local_reward.py
@@ -1,0 +1,83 @@
+"""Tests for YAML-configured local reward functions."""
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.config import ExperimentConfig, LocalRewardFunctionConfig, RewardAPIConfig
+from trainers.rewards.factory import build_reward_function
+from trainers.rewards.local_reward import LocalRewardFunction
+
+
+def test_local_reward_loads_configured_callable(caplog):
+    reward = LocalRewardFunction(
+        LocalRewardFunctionConfig(
+            function="trainers.rewards.accuracy_rewards:exact_match_reward_func"
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger="trainers.rewards.local_reward"):
+        scores = reward(
+            ["sensitive-prompt", "other-prompt"],
+            ["<answer>42</answer>", "<answer>0</answer>"],
+            answer=["42", "7"],
+        )
+
+    assert scores == [2.0, 0.0]
+    assert "scored 2 completions" in caplog.text
+    assert "sensitive-prompt" not in caplog.text
+
+
+def test_local_reward_validates_score_count():
+    reward = LocalRewardFunction(
+        LocalRewardFunctionConfig(
+            function="trainers.rewards.custom_rewards:custom_reward_func"
+        )
+    )
+    reward.function = lambda **_kwargs: []
+
+    with pytest.raises(ValueError, match="0 rewards for 1 completions"):
+        reward(["prompt"], ["completion"])
+
+
+def test_local_reward_config_rejects_invalid_import_path():
+    with pytest.raises(ValueError, match="module.path:function_name"):
+        LocalRewardFunctionConfig(function="missing_separator")
+
+
+def test_reward_factory_rejects_multiple_sources():
+    config = SimpleNamespace(
+        reward_api=RewardAPIConfig(endpoint="https://reward.example/score"),
+        local_reward_function=LocalRewardFunctionConfig(
+            function="trainers.rewards.custom_rewards:custom_reward_func"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="only one"):
+        build_reward_function(config)
+
+
+def test_local_reward_smoke_recipe_loads():
+    config = ExperimentConfig.from_yaml(
+        str(
+            REPO_ROOT
+            / "recipes"
+            / "training"
+            / "grpo"
+            / "llama3_3B_local_reward.yaml"
+        )
+    )
+
+    assert config.reward_api is None
+    assert config.local_reward_function is not None
+    assert (
+        config.local_reward_function.function
+        == "trainers.rewards.accuracy_rewards:exact_match_reward_func"
+    )

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,31 @@
+"""Tests for training configuration logging."""
+
+from utils.logging_utils import TrainingLogger
+
+
+class _CapturingLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(message)
+
+
+def test_experiment_logging_skips_unconfigured_optional_sections():
+    training_logger = TrainingLogger.__new__(TrainingLogger)
+    training_logger.logger = _CapturingLogger()
+
+    training_logger.log_experiment_start(
+        {
+            "algorithm": {"name": "grpo"},
+            "reward_api": None,
+            "local_reward_function": {
+                "function": "trainers.rewards.preset_rewards:exact_match_reward_func",
+                "kwargs": {},
+            },
+        }
+    )
+
+    assert "ALGORITHM:" in training_logger.logger.messages
+    assert "LOCAL_REWARD_FUNCTION:" in training_logger.logger.messages
+    assert "REWARD_API:" not in training_logger.logger.messages

--- a/trainers/README.md
+++ b/trainers/README.md
@@ -87,7 +87,7 @@ Replace the following values for your specific use case:
   - **SFT**: Use `prompt_column` and `answer_column`
   - **DPO**: Use `prompt_column`, `chosen_column`, and `rejected_column`
   - **GRPO/GSPO**: `prompt_column` is required. `answer_column` is optional;
-    all dataset columns are forwarded to the reward API as scoring context.
+    all dataset columns are forwarded to the configured reward function as scoring context.
 - `training.algorithm` → choose from: `cpt`, `sft`, `sft_vlm`, `dpo`, `grpo`, `gspo`
 - `training.output_dir` → your desired model output directory
 - `wandb.*` → your Weights & Biases configuration (or set `enabled: false` to disable)
@@ -97,8 +97,9 @@ Replace the following values for your specific use case:
 - **SFT**: Best for initial instruction tuning; requires `prompt_column` and `answer_column` in dataset
 - **DPO**: Preference-based method; requires `prompt_column`, `chosen_column`, and `rejected_column`
 - **GRPO/GSPO**: Requires `prompt_column`, an optional `answer_column` or other
-  scoring context, and a top-level `reward_api` configuration. Reward logic is
-  supplied by the configured HTTP service rather than built into FAI-RL.
+  scoring context, and exactly one of `reward_api` or `local_reward_function`.
+  HTTP rewards are the production path; local Python functions are intended only
+  for FAI-RL development and testing.
 
 ### GRPO/GSPO Reward API
 
@@ -142,6 +143,38 @@ number per completion:
 The service should be stateless or idempotent and sized for requests from every
 distributed training worker. HTTP errors, invalid JSON, missing rewards, and
 score-count mismatches fail training after the configured retries.
+
+### Local Reward Function (FAI-RL Testing Only)
+
+For local tests, a recipe can import a Python callable instead of making HTTP
+requests:
+
+```yaml
+local_reward_function:
+  function: "trainers.rewards.accuracy_rewards:exact_match_reward_func"
+  kwargs: {}
+```
+
+The runnable smoke-test recipe and dataset are:
+
+```bash
+fai-rl-train \
+  --recipe recipes/training/grpo/llama3_3B_local_reward.yaml \
+  --num-gpus 1
+```
+
+Do not configure `reward_api` in the same recipe. The callable is loaded from
+`module.path:function_name` and receives:
+
+```python
+def reward_function(prompts, completions, **kwargs) -> list[float]:
+    ...
+```
+
+Dataset context columns are included in `kwargs`; configured `kwargs` are also
+passed to the callable. It must return one finite numeric reward per completion.
+Local imports execute trusted Python code in every training worker and are not
+an ML Platform integration or production deployment mechanism.
 
 **Memory Optimization Tips:**
 - Reduce `per_device_train_batch_size` if you encounter OOM errors

--- a/trainers/README.md
+++ b/trainers/README.md
@@ -86,7 +86,8 @@ Replace the following values for your specific use case:
   - **CPT**: Use `text_column` (raw text, no chat template)
   - **SFT**: Use `prompt_column` and `answer_column`
   - **DPO**: Use `prompt_column`, `chosen_column`, and `rejected_column`
-  - **GRPO/GSPO**: Use `prompt_column` and `answer_column`
+  - **GRPO/GSPO**: `prompt_column` is required. `answer_column` is optional;
+    all dataset columns are forwarded to the reward API as scoring context.
 - `training.algorithm` → choose from: `cpt`, `sft`, `sft_vlm`, `dpo`, `grpo`, `gspo`
 - `training.output_dir` → your desired model output directory
 - `wandb.*` → your Weights & Biases configuration (or set `enabled: false` to disable)
@@ -95,7 +96,52 @@ Replace the following values for your specific use case:
 - **CPT**: Domain adaptation via next-token prediction on raw text; requires a `text_column` in dataset; no system prompt or chat template applied
 - **SFT**: Best for initial instruction tuning; requires `prompt_column` and `answer_column` in dataset
 - **DPO**: Preference-based method; requires `prompt_column`, `chosen_column`, and `rejected_column`
-- **GRPO/GSPO**: Math/reasoning task optimization; requires `prompt_column` and `answer_column`
+- **GRPO/GSPO**: Requires `prompt_column`, an optional `answer_column` or other
+  scoring context, and a top-level `reward_api` configuration. Reward logic is
+  supplied by the configured HTTP service rather than built into FAI-RL.
+
+### GRPO/GSPO Reward API
+
+Configure the scorer in the recipe:
+
+```yaml
+reward_api:
+  endpoint: "https://reward.example.com/v1/score"
+  api_key: null                       # Optional; null allows unauthenticated calls
+  auth_header: "Authorization"
+  auth_scheme: "Bearer"
+  timeout_seconds: 30
+  max_retries: 2
+  retry_backoff_seconds: 1
+  verify_ssl: true
+  headers: {}
+  extra_body: {}
+  response_field: "rewards"
+```
+
+Each training worker sends one POST per reward batch:
+
+```json
+{
+  "prompts": ["..."],
+  "completions": ["..."],
+  "context": {
+    "answer": ["..."]
+  }
+}
+```
+
+All unused dataset columns passed through TRL are included in `context`, so the
+service can implement arbitrary task-specific scoring. It must return one finite
+number per completion:
+
+```json
+{"rewards": [1.0]}
+```
+
+The service should be stateless or idempotent and sized for requests from every
+distributed training worker. HTTP errors, invalid JSON, missing rewards, and
+score-count mismatches fail training after the configured retries.
 
 **Memory Optimization Tips:**
 - Reduce `per_device_train_batch_size` if you encounter OOM errors
@@ -149,8 +195,8 @@ Relative paths are resolved from the directory where `fai-rl-train` is launched.
 | **SFT** | `prompt`, `response` |
 | **CPT** | `text` |
 | **DPO** | `prompt`, `chosen`, `rejected` |
-| **GRPO** | `prompt`, `answer` |
-| **GSPO** | `prompt`, `answer` |
+| **GRPO** | `prompt` (plus any reward context columns) |
+| **GSPO** | `prompt` (plus any reward context columns) |
 
 **Example — SFT from a local JSONL file**
 

--- a/trainers/README.md
+++ b/trainers/README.md
@@ -108,9 +108,6 @@ Configure the scorer in the recipe:
 ```yaml
 reward_api:
   endpoint: "https://reward.example.com/v1/score"
-  api_key: null                       # Optional; null allows unauthenticated calls
-  auth_header: "Authorization"
-  auth_scheme: "Bearer"
   timeout_seconds: 30
   max_retries: 2
   retry_backoff_seconds: 1

--- a/trainers/grpo_trainer.py
+++ b/trainers/grpo_trainer.py
@@ -16,7 +16,7 @@ from core.config import ExperimentConfig
 from core.trainer_base import BaseTrainer
 from utils.logging_utils import setup_logging
 from utils.dataset_utils import load_training_dataset
-from .rewards.api_reward import APIRewardFunction
+from .rewards.factory import build_reward_function
 
 class GRPOTrainer(BaseTrainer):
     """GRPO (Group Relative Policy Optimization) trainer implementation."""
@@ -183,10 +183,7 @@ class GRPOTrainer(BaseTrainer):
         """Initialize the GRPO trainer."""
         training_args = self.setup_training_args()
 
-        if not self.config.reward_api:
-            raise ValueError("reward_api configuration is required for GRPO")
-        self.logger.info("Using HTTP reward API: %s", self.config.reward_api.endpoint)
-        reward_func = APIRewardFunction(self.config.reward_api, logger=self.logger)
+        reward_func = build_reward_function(self.config, logger=self.logger)
 
         self.trainer = TRLGRPOTrainer(
             model=self.model,

--- a/trainers/grpo_trainer.py
+++ b/trainers/grpo_trainer.py
@@ -15,10 +15,8 @@ if project_root not in sys.path:
 from core.config import ExperimentConfig
 from core.trainer_base import BaseTrainer
 from utils.logging_utils import setup_logging
-from utils.dataset_utils import is_math_dataset, get_template_for_dataset, load_training_dataset
-from .rewards.accuracy_rewards import exact_match_reward_func, digit_reward_func
-from .rewards.format_rewards import structured_xml_reward_func
-from .rewards.custom_rewards import custom_reward_func
+from utils.dataset_utils import load_training_dataset
+from .rewards.api_reward import APIRewardFunction
 
 class GRPOTrainer(BaseTrainer):
     """GRPO (Group Relative Policy Optimization) trainer implementation."""
@@ -68,33 +66,27 @@ class GRPOTrainer(BaseTrainer):
 
             original_size = len(dataset)
 
-            # Get column names from config with defaults for math datasets
+            # Map the configured source prompt into TRL's expected column while
+            # preserving every other dataset column for the reward API context.
             prompt_col = getattr(dataset_info, "prompt_column", "question")
-            answer_col = getattr(dataset_info, "answer_column", "answer")
+            answer_col = getattr(dataset_info, "answer_column", None)
 
-            # Get appropriate template for this dataset
-            template_class = get_template_for_dataset(dataset_info.name, logger=self.logger)
-            processed_dataset = dataset.map(
-                lambda example: template_class.format_for_training(example, prompt_col, answer_col)
-            )
+            def map_configured_columns(example):
+                mapped = {"prompt": example.get(prompt_col)}
+                if answer_col and answer_col in example:
+                    mapped["answer"] = example.get(answer_col)
+                return mapped
 
-            # Filter out invalid rows where prompt or answer are None or empty
+            processed_dataset = dataset.map(map_configured_columns)
+
+            # A ground-truth answer is not mandatory: the external reward API can
+            # score against any dataset columns included in its context.
             def is_valid_example(example):
-                """Check if example has valid prompt and answer fields."""
+                """Check if an example has a usable configured prompt."""
                 prompt = example.get("prompt")
-                answer = example.get("answer")
-                
-                # Check prompt validity - can be string or list of dicts
-                prompt_valid = False
                 if isinstance(prompt, str):
-                    prompt_valid = prompt.strip() != ""
-                elif isinstance(prompt, list) and len(prompt) > 0:
-                    prompt_valid = True
-                
-                # Check answer validity
-                answer_valid = answer is not None and isinstance(answer, str) and answer.strip() != ""
-                
-                return prompt_valid and answer_valid
+                    return bool(prompt.strip())
+                return isinstance(prompt, list) and len(prompt) > 0
             
             processed_dataset = processed_dataset.filter(is_valid_example)
             
@@ -104,7 +96,7 @@ class GRPOTrainer(BaseTrainer):
             if skipped > 0:
                 self.logger.warning(
                     f"Skipped {skipped} invalid examples from {dataset_info.name} "
-                    f"(missing or empty 'prompt'/'answer' fields)"
+                    f"(missing or empty configured prompt column '{prompt_col}')"
                 )
 
             datasets.append(processed_dataset)
@@ -121,12 +113,22 @@ class GRPOTrainer(BaseTrainer):
         # This is required because GRPO expects prompts to be strings, not message dicts
         def apply_chat_template(example):
             prompt = example['prompt']
-            # If prompt is a list of message dicts, apply chat template
+            # Existing conversational prompts pass through directly. For a plain
+            # prompt, an optional configured system instruction creates a chat.
             if isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
                 example['prompt'] = self.tokenizer.apply_chat_template(
                     prompt, 
                     tokenize=False, 
                     add_generation_prompt=True
+                )
+            elif self.config.data.system_prompt:
+                example['prompt'] = self.tokenizer.apply_chat_template(
+                    [
+                        {"role": "system", "content": self.config.data.system_prompt},
+                        {"role": "user", "content": str(prompt)},
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
                 )
             return example
         
@@ -181,39 +183,14 @@ class GRPOTrainer(BaseTrainer):
         """Initialize the GRPO trainer."""
         training_args = self.setup_training_args()
 
-        # Use math-specific reward functions
-        self.logger.info("Using math-specific reward functions")
-        
-        # Create wrapper functions that inject the logger into reward functions
-        def exact_match_with_logger(prompts, completions, answer, **kwargs):
-            kwargs['logger'] = self.logger
-            return exact_match_reward_func(completions, answer, **kwargs)
-        
-        def structured_xml_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return structured_xml_reward_func(completions, **kwargs)
-        
-        def digit_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return digit_reward_func(completions, **kwargs)
-        
-        # ========== CUSTOM REWARD FUNCTION ==========
-        # Add your custom reward logic here
-        def custom_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return custom_reward_func(completions, **kwargs)
-        # ============================================
-        
-        reward_funcs = [
-            exact_match_with_logger,
-            structured_xml_with_logger,
-            digit_with_logger,
-            custom_with_logger,  # Add your custom reward function here
-        ]
+        if not self.config.reward_api:
+            raise ValueError("reward_api configuration is required for GRPO")
+        self.logger.info("Using HTTP reward API: %s", self.config.reward_api.endpoint)
+        reward_func = APIRewardFunction(self.config.reward_api, logger=self.logger)
 
         self.trainer = TRLGRPOTrainer(
             model=self.model,
-            reward_funcs=reward_funcs,
+            reward_funcs=[reward_func],
             args=training_args,
             train_dataset=self.train_dataset,
             callbacks=self.build_callbacks(),

--- a/trainers/gspo_trainer.py
+++ b/trainers/gspo_trainer.py
@@ -17,10 +17,8 @@ if project_root not in sys.path:
 from core.config import ExperimentConfig
 from core.trainer_base import BaseTrainer
 from utils.logging_utils import setup_logging
-from utils.dataset_utils import is_math_dataset, get_template_for_dataset, load_training_dataset
-from .rewards.accuracy_rewards import exact_match_reward_func, digit_reward_func
-from .rewards.format_rewards import structured_xml_reward_func
-from .rewards.custom_rewards import custom_reward_func
+from utils.dataset_utils import load_training_dataset
+from .rewards.api_reward import APIRewardFunction
 
 class GSPOTrainer(BaseTrainer):
     """GSPO (Group Sequence Policy Optimization) trainer implementation."""
@@ -73,33 +71,27 @@ class GSPOTrainer(BaseTrainer):
 
             original_size = len(dataset)
 
-            # Get column names from config with defaults for math datasets
+            # Map the configured source prompt into TRL's expected column while
+            # preserving every other dataset column for the reward API context.
             prompt_col = getattr(dataset_info, "prompt_column", "question")
-            answer_col = getattr(dataset_info, "answer_column", "answer")
+            answer_col = getattr(dataset_info, "answer_column", None)
 
-            # Get appropriate template for this dataset
-            template_class = get_template_for_dataset(dataset_info.name, logger=self.logger)
-            processed_dataset = dataset.map(
-                lambda example: template_class.format_for_training(example, prompt_col, answer_col)
-            )
+            def map_configured_columns(example):
+                mapped = {"prompt": example.get(prompt_col)}
+                if answer_col and answer_col in example:
+                    mapped["answer"] = example.get(answer_col)
+                return mapped
 
-            # Filter out invalid rows where prompt or answer are None or empty
+            processed_dataset = dataset.map(map_configured_columns)
+
+            # A ground-truth answer is not mandatory: the external reward API can
+            # score against any dataset columns included in its context.
             def is_valid_example(example):
-                """Check if example has valid prompt and answer fields."""
+                """Check if an example has a usable configured prompt."""
                 prompt = example.get("prompt")
-                answer = example.get("answer")
-                
-                # Check prompt validity - can be string or list of dicts
-                prompt_valid = False
                 if isinstance(prompt, str):
-                    prompt_valid = prompt.strip() != ""
-                elif isinstance(prompt, list) and len(prompt) > 0:
-                    prompt_valid = True
-                
-                # Check answer validity
-                answer_valid = answer is not None and isinstance(answer, str) and answer.strip() != ""
-                
-                return prompt_valid and answer_valid
+                    return bool(prompt.strip())
+                return isinstance(prompt, list) and len(prompt) > 0
             
             processed_dataset = processed_dataset.filter(is_valid_example)
             
@@ -109,7 +101,7 @@ class GSPOTrainer(BaseTrainer):
             if skipped > 0:
                 self.logger.warning(
                     f"Skipped {skipped} invalid examples from {dataset_info.name} "
-                    f"(missing or empty 'prompt'/'answer' fields)"
+                    f"(missing or empty configured prompt column '{prompt_col}')"
                 )
 
             datasets.append(processed_dataset)
@@ -126,12 +118,22 @@ class GSPOTrainer(BaseTrainer):
         # This is required because GSPO expects prompts to be strings, not message dicts
         def apply_chat_template(example):
             prompt = example['prompt']
-            # If prompt is a list of message dicts, apply chat template
+            # Existing conversational prompts pass through directly. For a plain
+            # prompt, an optional configured system instruction creates a chat.
             if isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
                 example['prompt'] = self.tokenizer.apply_chat_template(
                     prompt, 
                     tokenize=False, 
                     add_generation_prompt=True
+                )
+            elif self.config.data.system_prompt:
+                example['prompt'] = self.tokenizer.apply_chat_template(
+                    [
+                        {"role": "system", "content": self.config.data.system_prompt},
+                        {"role": "user", "content": str(prompt)},
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
                 )
             return example
         
@@ -192,39 +194,14 @@ class GSPOTrainer(BaseTrainer):
         """Initialize the GSPO trainer."""
         training_args = self.setup_training_args()
 
-        # Use math-specific reward functions
-        self.logger.info("Using math-specific reward functions")
-        
-        # Create wrapper functions that inject the logger into reward functions
-        def exact_match_with_logger(prompts, completions, answer, **kwargs):
-            kwargs['logger'] = self.logger
-            return exact_match_reward_func(completions, answer, **kwargs)
-        
-        def structured_xml_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return structured_xml_reward_func(completions, **kwargs)
-        
-        def digit_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return digit_reward_func(completions, **kwargs)
-        
-        # ========== CUSTOM REWARD FUNCTION ==========
-        # Add your custom reward logic here
-        def custom_with_logger(prompts, completions, **kwargs):
-            kwargs['logger'] = self.logger
-            return custom_reward_func(completions, **kwargs)
-        # ============================================
-        
-        reward_funcs = [
-            exact_match_with_logger,
-            structured_xml_with_logger,
-            digit_with_logger,
-            custom_with_logger,  # Add your custom reward function here
-        ]
+        if not self.config.reward_api:
+            raise ValueError("reward_api configuration is required for GSPO")
+        self.logger.info("Using HTTP reward API: %s", self.config.reward_api.endpoint)
+        reward_func = APIRewardFunction(self.config.reward_api, logger=self.logger)
 
         self.trainer = TRLGSPOTrainer(
             model=self.model,
-            reward_funcs=reward_funcs,
+            reward_funcs=[reward_func],
             args=training_args,
             train_dataset=self.train_dataset,
             callbacks=self.build_callbacks(),

--- a/trainers/gspo_trainer.py
+++ b/trainers/gspo_trainer.py
@@ -18,7 +18,7 @@ from core.config import ExperimentConfig
 from core.trainer_base import BaseTrainer
 from utils.logging_utils import setup_logging
 from utils.dataset_utils import load_training_dataset
-from .rewards.api_reward import APIRewardFunction
+from .rewards.factory import build_reward_function
 
 class GSPOTrainer(BaseTrainer):
     """GSPO (Group Sequence Policy Optimization) trainer implementation."""
@@ -194,10 +194,7 @@ class GSPOTrainer(BaseTrainer):
         """Initialize the GSPO trainer."""
         training_args = self.setup_training_args()
 
-        if not self.config.reward_api:
-            raise ValueError("reward_api configuration is required for GSPO")
-        self.logger.info("Using HTTP reward API: %s", self.config.reward_api.endpoint)
-        reward_func = APIRewardFunction(self.config.reward_api, logger=self.logger)
+        reward_func = build_reward_function(self.config, logger=self.logger)
 
         self.trainer = TRLGSPOTrainer(
             model=self.model,

--- a/trainers/rewards/api_reward.py
+++ b/trainers/rewards/api_reward.py
@@ -35,12 +35,7 @@ class APIRewardFunction:
         self.logger = logger or logging.getLogger(__name__)
 
     def _headers(self) -> Dict[str, str]:
-        headers = {"Content-Type": "application/json", **self.config.headers}
-        api_key = self.config.api_key
-        if api_key:
-            value = f"{self.config.auth_scheme} {api_key}".strip()
-            headers[self.config.auth_header] = value
-        return headers
+        return {"Content-Type": "application/json", **self.config.headers}
 
     def __call__(self, prompts, completions, **kwargs) -> List[float]:
         context = {key: value for key, value in kwargs.items() if key != "logger"}

--- a/trainers/rewards/api_reward.py
+++ b/trainers/rewards/api_reward.py
@@ -33,6 +33,7 @@ class APIRewardFunction:
     def __init__(self, config: RewardAPIConfig, logger=None):
         self.config = config
         self.logger = logger or logging.getLogger(__name__)
+        self.__name__ = "api_reward"
 
     def _headers(self) -> Dict[str, str]:
         return {"Content-Type": "application/json", **self.config.headers}

--- a/trainers/rewards/api_reward.py
+++ b/trainers/rewards/api_reward.py
@@ -1,0 +1,104 @@
+"""HTTP-backed reward function for GRPO and GSPO."""
+
+import math
+import time
+from typing import Any, Dict, List
+
+import requests
+
+from core.config import RewardAPIConfig
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert common tensor/array containers into JSON-compatible values."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "tolist"):
+        return _json_safe(value.tolist())
+    if hasattr(value, "item"):
+        return _json_safe(value.item())
+    raise TypeError(
+        f"Reward API context contains a non-JSON-serializable value: {type(value).__name__}"
+    )
+
+
+class APIRewardFunction:
+    """TRL-compatible callable that delegates reward calculation to an HTTP API."""
+
+    def __init__(self, config: RewardAPIConfig, logger=None):
+        self.config = config
+        self.logger = logger
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json", **self.config.headers}
+        api_key = self.config.api_key
+        if api_key:
+            value = f"{self.config.auth_scheme} {api_key}".strip()
+            headers[self.config.auth_header] = value
+        return headers
+
+    def __call__(self, prompts, completions, **kwargs) -> List[float]:
+        context = {key: value for key, value in kwargs.items() if key != "logger"}
+        payload = {
+            **_json_safe(self.config.extra_body),
+            "prompts": _json_safe(prompts),
+            "completions": _json_safe(completions),
+            "context": _json_safe(context),
+        }
+
+        last_error = None
+        attempts = self.config.max_retries + 1
+        for attempt in range(attempts):
+            try:
+                response = requests.post(
+                    self.config.endpoint,
+                    headers=self._headers(),
+                    json=payload,
+                    timeout=self.config.timeout_seconds,
+                    verify=self.config.verify_ssl,
+                )
+                response.raise_for_status()
+                body = response.json()
+                rewards = body[self.config.response_field]
+                return self._validate_rewards(rewards, len(completions))
+            except (KeyError, TypeError, ValueError, requests.RequestException) as exc:
+                last_error = exc
+                if attempt == self.config.max_retries:
+                    break
+                delay = self.config.retry_backoff_seconds * (2**attempt)
+                if self.logger:
+                    self.logger.warning(
+                        "Reward API request failed (%s); retrying in %.1fs",
+                        exc,
+                        delay,
+                    )
+                time.sleep(delay)
+
+        raise RuntimeError(
+            f"Reward API failed after {attempts} attempt(s): {last_error}"
+        ) from last_error
+
+    def _validate_rewards(self, rewards: Any, expected_count: int) -> List[float]:
+        if not isinstance(rewards, list):
+            raise TypeError(
+                f"Reward API field '{self.config.response_field}' must be a list"
+            )
+        if len(rewards) != expected_count:
+            raise ValueError(
+                f"Reward API returned {len(rewards)} rewards for "
+                f"{expected_count} completions"
+            )
+
+        scores = []
+        for reward in rewards:
+            if isinstance(reward, bool):
+                raise TypeError("Reward API scores must be numbers, not booleans")
+            score = float(reward)
+            if not math.isfinite(score):
+                raise ValueError("Reward API scores must be finite")
+            scores.append(score)
+        return scores

--- a/trainers/rewards/api_reward.py
+++ b/trainers/rewards/api_reward.py
@@ -1,5 +1,6 @@
 """HTTP-backed reward function for GRPO and GSPO."""
 
+import logging
 import math
 import time
 from typing import Any, Dict, List
@@ -31,7 +32,7 @@ class APIRewardFunction:
 
     def __init__(self, config: RewardAPIConfig, logger=None):
         self.config = config
-        self.logger = logger
+        self.logger = logger or logging.getLogger(__name__)
 
     def _headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json", **self.config.headers}
@@ -52,8 +53,16 @@ class APIRewardFunction:
 
         last_error = None
         attempts = self.config.max_retries + 1
+        started_at = time.monotonic()
         for attempt in range(attempts):
             try:
+                self.logger.debug(
+                    "Calling reward API endpoint=%s completions=%d attempt=%d/%d",
+                    self.config.endpoint,
+                    len(completions),
+                    attempt + 1,
+                    attempts,
+                )
                 response = requests.post(
                     self.config.endpoint,
                     headers=self._headers(),
@@ -64,20 +73,51 @@ class APIRewardFunction:
                 response.raise_for_status()
                 body = response.json()
                 rewards = body[self.config.response_field]
-                return self._validate_rewards(rewards, len(completions))
+                scores = self._validate_rewards(rewards, len(completions))
+                elapsed_seconds = time.monotonic() - started_at
+                if scores:
+                    self.logger.info(
+                        "Reward API scored %d completions in %.3fs "
+                        "(attempt=%d/%d min=%.4f max=%.4f mean=%.4f)",
+                        len(scores),
+                        elapsed_seconds,
+                        attempt + 1,
+                        attempts,
+                        min(scores),
+                        max(scores),
+                        sum(scores) / len(scores),
+                    )
+                else:
+                    self.logger.info(
+                        "Reward API scored an empty batch in %.3fs (attempt=%d/%d)",
+                        elapsed_seconds,
+                        attempt + 1,
+                        attempts,
+                    )
+                return scores
             except (KeyError, TypeError, ValueError, requests.RequestException) as exc:
                 last_error = exc
                 if attempt == self.config.max_retries:
                     break
                 delay = self.config.retry_backoff_seconds * (2**attempt)
-                if self.logger:
-                    self.logger.warning(
-                        "Reward API request failed (%s); retrying in %.1fs",
-                        exc,
-                        delay,
-                    )
+                self.logger.warning(
+                    "Reward API request failed endpoint=%s attempt=%d/%d (%s); "
+                    "retrying in %.1fs",
+                    self.config.endpoint,
+                    attempt + 1,
+                    attempts,
+                    exc,
+                    delay,
+                )
                 time.sleep(delay)
 
+        self.logger.error(
+            "Reward API failed endpoint=%s attempts=%d elapsed_seconds=%.3f error=%s",
+            self.config.endpoint,
+            attempts,
+            time.monotonic() - started_at,
+            last_error,
+        )
         raise RuntimeError(
             f"Reward API failed after {attempts} attempt(s): {last_error}"
         ) from last_error

--- a/trainers/rewards/factory.py
+++ b/trainers/rewards/factory.py
@@ -1,0 +1,28 @@
+"""Reward function selection for GRPO and GSPO trainers."""
+
+from core.config import ExperimentConfig
+
+from .api_reward import APIRewardFunction
+from .local_reward import LocalRewardFunction
+
+
+def build_reward_function(config: ExperimentConfig, logger=None):
+    """Build exactly one configured HTTP or local reward function."""
+    if config.reward_api and config.local_reward_function:
+        raise ValueError(
+            "Configure only one of reward_api or local_reward_function"
+        )
+    if config.reward_api:
+        if logger:
+            logger.info("Using HTTP reward API: %s", config.reward_api.endpoint)
+        return APIRewardFunction(config.reward_api, logger=logger)
+    if config.local_reward_function:
+        if logger:
+            logger.warning(
+                "Using local reward function for testing only: %s",
+                config.local_reward_function.function,
+            )
+        return LocalRewardFunction(config.local_reward_function, logger=logger)
+    raise ValueError(
+        "GRPO/GSPO requires reward_api or local_reward_function configuration"
+    )

--- a/trainers/rewards/local_reward.py
+++ b/trainers/rewards/local_reward.py
@@ -1,0 +1,83 @@
+"""TRL-compatible adapter for locally imported reward functions."""
+
+import importlib
+import logging
+import math
+from typing import Any, Callable, List
+
+from core.config import LocalRewardFunctionConfig
+
+
+class LocalRewardFunction:
+    """Load and validate a local Python reward callable."""
+
+    def __init__(self, config: LocalRewardFunctionConfig, logger=None):
+        self.config = config
+        self.logger = logger or logging.getLogger(__name__)
+        self.function = self._load_function(config.function)
+
+    @staticmethod
+    def _load_function(import_path: str) -> Callable:
+        module_name, function_name = import_path.split(":", 1)
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError as exc:
+            raise ImportError(
+                f"Could not import local reward module '{module_name}'"
+            ) from exc
+
+        function = getattr(module, function_name, None)
+        if not callable(function):
+            raise ValueError(
+                f"Local reward '{import_path}' does not resolve to a callable"
+            )
+        return function
+
+    def __call__(self, prompts, completions, **kwargs) -> List[float]:
+        call_kwargs = {
+            **kwargs,
+            **self.config.kwargs,
+            "logger": self.logger,
+        }
+        rewards = self.function(
+            prompts=prompts,
+            completions=completions,
+            **call_kwargs,
+        )
+        scores = self._validate_rewards(rewards, len(completions))
+        if scores:
+            self.logger.info(
+                "Local reward function=%s scored %d completions "
+                "(min=%.4f max=%.4f mean=%.4f)",
+                self.config.function,
+                len(scores),
+                min(scores),
+                max(scores),
+                sum(scores) / len(scores),
+            )
+        else:
+            self.logger.info(
+                "Local reward function=%s scored an empty batch",
+                self.config.function,
+            )
+        return scores
+
+    @staticmethod
+    def _validate_rewards(rewards: Any, expected_count: int) -> List[float]:
+        if not isinstance(rewards, list):
+            raise TypeError("Local reward function must return a list")
+        if len(rewards) != expected_count:
+            raise ValueError(
+                f"Local reward function returned {len(rewards)} rewards for "
+                f"{expected_count} completions"
+            )
+
+        scores = []
+        for reward in rewards:
+            if isinstance(reward, bool):
+                raise TypeError("Local reward scores must be numbers, not booleans")
+            score = float(reward)
+            if not math.isfinite(score):
+                raise ValueError("Local reward scores must be finite")
+            scores.append(score)
+        return scores

--- a/trainers/rewards/local_reward.py
+++ b/trainers/rewards/local_reward.py
@@ -15,6 +15,11 @@ class LocalRewardFunction:
         self.config = config
         self.logger = logger or logging.getLogger(__name__)
         self.function = self._load_function(config.function)
+        self.__name__ = getattr(
+            self.function,
+            "__name__",
+            config.function.rsplit(":", 1)[-1],
+        )
 
     @staticmethod
     def _load_function(import_path: str) -> Callable:

--- a/trainers/train.py
+++ b/trainers/train.py
@@ -17,7 +17,16 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from core.config import ExperimentConfig, ModelConfig, DataConfig, TrainingConfig, WandbConfig, S3Config, DatasetInfo
+from core.config import (
+    DataConfig,
+    DatasetInfo,
+    ExperimentConfig,
+    ModelConfig,
+    RewardAPIConfig,
+    S3Config,
+    TrainingConfig,
+    WandbConfig,
+)
 from trainers.cpt_trainer import CPTTrainer
 from trainers.dpo_trainer import DPOTrainer
 from trainers.grpo_trainer import GRPOTrainer
@@ -303,13 +312,24 @@ def load_recipe_with_overrides(args) -> ExperimentConfig:
         data_config['datasets'] = []
     
     # Create config objects with defaults
-    return ExperimentConfig(
+    config = ExperimentConfig(
         model=ModelConfig(**recipe_dict.get('model', {})),
         data=DataConfig(**data_config),
         training=TrainingConfig(**recipe_dict.get('training', {})),
         wandb=WandbConfig(**recipe_dict.get('wandb', {})),
         s3=S3Config(**recipe_dict.get('s3', {})),
+        reward_api=(
+            RewardAPIConfig(**recipe_dict['reward_api'])
+            if recipe_dict.get('reward_api')
+            else None
+        ),
     )
+    if config.training.algorithm.lower() in {"grpo", "gspo"} and not config.reward_api:
+        raise ValueError(
+            "reward_api configuration is required for GRPO/GSPO. "
+            "Configure an HTTP reward endpoint in the recipe."
+        )
+    return config
 
 
 def main():
@@ -411,6 +431,7 @@ def main():
         "training": config.training.to_dict(),
         "wandb": config.wandb.to_dict(),
         "s3": config.s3.to_dict(),
+        "reward_api": config.reward_api.to_dict() if config.reward_api else None,
     }
     
     training_logger.log_experiment_start(log_dict)

--- a/trainers/train.py
+++ b/trainers/train.py
@@ -21,6 +21,7 @@ from core.config import (
     DataConfig,
     DatasetInfo,
     ExperimentConfig,
+    LocalRewardFunctionConfig,
     ModelConfig,
     RewardAPIConfig,
     S3Config,
@@ -323,12 +324,21 @@ def load_recipe_with_overrides(args) -> ExperimentConfig:
             if recipe_dict.get('reward_api')
             else None
         ),
+        local_reward_function=(
+            LocalRewardFunctionConfig(**recipe_dict['local_reward_function'])
+            if recipe_dict.get('local_reward_function')
+            else None
+        ),
     )
-    if config.training.algorithm.lower() in {"grpo", "gspo"} and not config.reward_api:
-        raise ValueError(
-            "reward_api configuration is required for GRPO/GSPO. "
-            "Configure an HTTP reward endpoint in the recipe."
-        )
+    if config.training.algorithm.lower() in {"grpo", "gspo"}:
+        if config.reward_api and config.local_reward_function:
+            raise ValueError(
+                "Configure only one of reward_api or local_reward_function"
+            )
+        if not config.reward_api and not config.local_reward_function:
+            raise ValueError(
+                "GRPO/GSPO requires reward_api or local_reward_function configuration"
+            )
     return config
 
 
@@ -432,6 +442,11 @@ def main():
         "wandb": config.wandb.to_dict(),
         "s3": config.s3.to_dict(),
         "reward_api": config.reward_api.to_dict() if config.reward_api else None,
+        "local_reward_function": (
+            config.local_reward_function.to_dict()
+            if config.local_reward_function
+            else None
+        ),
     }
     
     training_logger.log_experiment_start(log_dict)

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -307,6 +307,8 @@ class TrainingLogger:
         self.logger.info("="*50)
 
         for section, values in config.items():
+            if values is None:
+                continue
             self.logger.info(f"{section.upper()}:")
             for k, v in values.items():
                 self.logger.info(f"  {k}: {v}")


### PR DESCRIPTION
## Summary
- Add configurable HTTP reward APIs for GRPO and GSPO
- Replace hard-coded local reward functions with batched external scoring
- Support unauthenticated requests, custom headers, retries, timeouts, and response fields
- Preserve arbitrary dataset columns as reward context
- Update recipes and documentation
- Bump FAI-RL to 0.2.9

## Test plan
- Run API reward unit tests
- Run GRPO/GSPO configuration tests
- Verify malformed responses and retry behavior