### PR TITLE
fix(lora): adapt Gemma4ClippableLinear via inner Linear

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -42,10 +42,9 @@ class ModelConfig:
     lora_target_modules: Optional[List[str]] = None
     # Module name patterns to exclude from LoRA injection even if they match
     # lora_target_modules. Needed for VLMs, where the (frozen) vision tower has
-    # attention projections named like the language model's (q_proj/k_proj/...)
-    # but wrapped in custom module types PEFT can't adapt. The sft_vlm trainer
-    # auto-populates this with the vision tower when freeze_vision_tower is set
-    # and no explicit list is given.
+    # attention projections named like the language model's (q_proj/k_proj/...).
+    # The sft_vlm trainer auto-populates this with the vision tower when
+    # freeze_vision_tower is set and no explicit list is given.
     #
     # A list matches leaf module names (suffix match); a single string is treated
     # by PEFT as a regex full-matched against the whole module path, which is what

--- a/core/peft_lora.py
+++ b/core/peft_lora.py
@@ -1,0 +1,115 @@
+"""PEFT LoRA helpers for module types stock PEFT cannot wrap.
+
+Gemma 4 E-series language stacks and Gemma 4 vision/audio towers use
+``Gemma4ClippableLinear``: an ``nn.Module`` wrapping an inner ``nn.Linear``
+(or bitsandbytes ``Linear4bit`` / ``Linear8bitLt``) with optional activation
+clipping. PEFT LoRA only dispatches to ``nn.Linear`` and a few other stock
+types, so ``target_modules`` like ``q_proj`` raise:
+
+    Target module Gemma4ClippableLinear(...) is not supported.
+
+PEFT 0.19 exposes experimental ``LoraConfig._register_custom_module``. We
+register a factory that LoRA-wraps the inner ``.linear`` via PEFT's normal
+dispatch (so QLoRA 4-bit/8-bit backends still run) and re-applies clipping
+around that adapter. The outer wrapper is not replaced with a bare
+``nn.Linear``. Custom modules are not serialized in adapter configs; re-register
+before ``PeftModel.from_pretrained``.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+_CLIP_BUFFERS = ("input_min", "input_max", "output_min", "output_max")
+
+
+def _gemma4_clippable_linear_cls() -> Optional[type]:
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+    except ImportError:
+        return None
+    return Gemma4ClippableLinear
+
+
+def _copy_clip_buffers(lora_layer: nn.Module, original: nn.Module) -> None:
+    for name in _CLIP_BUFFERS:
+        buf = getattr(original, name, None)
+        if buf is None:
+            continue
+        tensor = buf.detach().clone() if torch.is_tensor(buf) else buf
+        if name in lora_layer._buffers:
+            del lora_layer._buffers[name]
+        lora_layer.register_buffer(name, tensor)
+
+
+def _install_clipping(lora_layer: nn.Module, original: nn.Module) -> nn.Module:
+    """Keep Gemma4 clip semantics on the LoRA-wrapped inner linear."""
+    use_clip = bool(getattr(original, "use_clipped_linears", False))
+    lora_layer.use_clipped_linears = use_clip
+    if not use_clip:
+        return lora_layer
+
+    _copy_clip_buffers(lora_layer, original)
+    orig_forward = lora_layer.forward
+
+    def clipped_forward(self, x, *args, **kwargs):
+        x = torch.clamp(x, self.input_min, self.input_max)
+        out = orig_forward(x, *args, **kwargs)
+        return torch.clamp(out, self.output_min, self.output_max)
+
+    lora_layer.forward = types.MethodType(clipped_forward, lora_layer)
+    return lora_layer
+
+
+def _lora_wrap_clippable_linear(base_layer, adapter_name, config, **kwargs):
+    """Custom LoRA factory: adapt ``base_layer.linear``, keep clipping.
+
+    Clears ``config._custom_modules`` while dispatching the inner layer so PEFT
+    uses stock Linear / bitsandbytes QLoRA dispatchers instead of recursing.
+    """
+    inner = getattr(base_layer, "linear", None)
+    if inner is None:
+        raise TypeError(f"{type(base_layer).__name__} has no inner .linear to adapt with LoRA")
+
+    from peft.tuners.lora.model import LoraModel
+
+    saved = getattr(config, "_custom_modules", None)
+    config._custom_modules = None
+    try:
+        lora_layer = LoraModel._create_new_module(config, adapter_name, inner, **kwargs)
+    finally:
+        config._custom_modules = saved
+
+    return _install_clipping(lora_layer, base_layer)
+
+
+def register_clippable_linear_lora(peft_config) -> Any:
+    """Register Gemma4ClippableLinear on a PEFT config if the class exists.
+
+    No-op when transformers has no Gemma 4 module or the config has no
+    ``_register_custom_module`` (older peft). Call again after
+    ``LoraConfig.from_pretrained`` because custom modules are not serialized.
+    """
+    register = getattr(peft_config, "_register_custom_module", None)
+    if register is None:
+        return peft_config
+    cls = _gemma4_clippable_linear_cls()
+    if cls is None:
+        return peft_config
+    register({cls: _lora_wrap_clippable_linear})
+    return peft_config
+
+
+def peft_model_from_pretrained(model, model_id, **kwargs):
+    """``PeftModel.from_pretrained`` with Gemma4ClippableLinear re-registered."""
+    from peft import PeftConfig, PeftModel
+
+    config = kwargs.pop("config", None)
+    if config is None:
+        config = PeftConfig.from_pretrained(model_id)
+    register_clippable_linear_lora(config)
+    return PeftModel.from_pretrained(model, model_id, config=config, **kwargs)

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -131,6 +131,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import LoraConfig, get_peft_model, TaskType, prepare_model_for_kbit_training
 
 from .config import ExperimentConfig
+from .peft_lora import peft_model_from_pretrained, register_clippable_linear_lora
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
@@ -699,9 +700,8 @@ class BaseTrainer(ABC):
 
         peft_adapter_path = getattr(self, '_peft_adapter_path', None)
         if peft_adapter_path is not None:
-            from peft import PeftModel
             self.logger.info("Loading existing PEFT adapter from %s", peft_adapter_path)
-            model = PeftModel.from_pretrained(model, peft_adapter_path, is_trainable=True)
+            model = peft_model_from_pretrained(model, peft_adapter_path, is_trainable=True)
             trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
             total_params = sum(p.numel() for p in model.parameters())
             self.logger.info(
@@ -739,14 +739,17 @@ class BaseTrainer(ABC):
         )
         # exclude_modules keeps target-module name matching (e.g. q_proj) from
         # leaking into submodules we must not adapt -- notably a VLM's frozen
-        # vision tower, whose attention projections share those names but are
-        # custom module types PEFT cannot wrap. Only pass it when set so we stay
-        # compatible with peft versions lacking the field.
+        # vision tower, whose attention projections share those names. Only pass
+        # it when set so we stay compatible with peft versions lacking the field.
         exclude_modules = getattr(self.config.model, "lora_exclude_modules", None)
         if exclude_modules:
             lora_kwargs["exclude_modules"] = exclude_modules
         lora_config = LoraConfig(**lora_kwargs)
-        
+        # Gemma4ClippableLinear (E-series language + vision/audio towers) is an
+        # nn.Module wrapping inner .linear. Register it so q_proj/etc. still
+        # match; PEFT adapts the inner linear instead of raising.
+        register_clippable_linear_lora(lora_config)
+
         # Apply LoRA to model
         model = get_peft_model(model, lora_config)
         

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -41,9 +41,10 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pydantic._intern
 warnings.filterwarnings("ignore", message=".*'repr' attribute.*has no effect.*")
 warnings.filterwarnings("ignore", message=".*'frozen' attribute.*has no effect.*")
 from pathlib import Path
-from peft import PeftModel, PeftConfig
+from peft import PeftConfig
 
 from core.config import ExperimentConfig
+from core.peft_lora import peft_model_from_pretrained
 from utils.config_validation import validate_api_config
 from utils.recipe_overrides import apply_overrides_to_recipe, load_recipe_from_yaml
 from utils.logging_utils import setup_logging, SafeLogger
@@ -303,7 +304,7 @@ def load_model_and_tokenizer(config):
         
         # Now load the PEFT adapter
         print("Loading PEFT adapter...")
-        model = PeftModel.from_pretrained(model, model_identifier)
+        model = peft_model_from_pretrained(model, model_identifier)
         
         # Merge adapter weights for faster inference
         print("Merging adapter weights...")
@@ -432,7 +433,7 @@ def load_vlm_model_and_processor(config):
         model = AutoModelForImageTextToText.from_pretrained(base_model_name, **model_load_kwargs)
 
         print("Loading PEFT adapter...")
-        model = PeftModel.from_pretrained(model, model_identifier)
+        model = peft_model_from_pretrained(model, model_identifier)
 
         print("Merging adapter weights...")
         model = model.merge_and_unload()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.9"
+version = "0.2.10"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_clippable_linear_lora.py
+++ b/tests/test_clippable_linear_lora.py
@@ -1,0 +1,233 @@
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from peft import LoraConfig, get_peft_model
+from peft.tuners.tuners_utils import BaseTunerLayer
+from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.peft_lora import peft_model_from_pretrained, register_clippable_linear_lora
+from core.trainer_base import BaseTrainer
+
+
+class ConcreteTrainer(BaseTrainer):
+    def setup_model(self):
+        pass
+
+    def setup_data(self):
+        pass
+
+    def setup_trainer(self):
+        pass
+
+    def train(self):
+        pass
+
+
+class _ClipCfg:
+    use_clipped_linears = True
+
+
+def _prepare_inputs_for_generation(self, input_ids=None, **kwargs):
+    # PeftModelForCausalLM requires this HF generate hook on the base module.
+    return {"input_ids": input_ids, **kwargs}
+
+
+class _LanguageAndVision(nn.Module):
+    def __init__(self, hidden=8):
+        super().__init__()
+        cfg = _ClipCfg()
+        self.q_proj = Gemma4ClippableLinear(cfg, hidden, hidden)
+        self.vision_tower = nn.Module()
+        self.vision_tower.q_proj = Gemma4ClippableLinear(cfg, hidden, hidden)
+
+    def forward(self, x):
+        return self.q_proj(x)
+
+    prepare_inputs_for_generation = _prepare_inputs_for_generation
+
+
+class _PlainLinearLM(nn.Module):
+    def __init__(self, hidden=8):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, x):
+        return self.q_proj(x)
+
+    prepare_inputs_for_generation = _prepare_inputs_for_generation
+
+
+def _lora_config(**extra):
+    kwargs = dict(
+        r=4,
+        lora_alpha=8,
+        lora_dropout=0.0,
+        target_modules=["q_proj"],
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    kwargs.update(extra)
+    return LoraConfig(**kwargs)
+
+
+def _trainer_for_lora(exclude_modules=None):
+    trainer = object.__new__(ConcreteTrainer)
+    trainer.logger = logging.getLogger("test_clippable_linear_lora")
+    trainer._peft_adapter_path = None
+    trainer.config = SimpleNamespace(
+        model=SimpleNamespace(
+            use_lora=True,
+            load_in_4bit=False,
+            load_in_8bit=False,
+            lora_r=4,
+            lora_alpha=8,
+            lora_dropout=0.0,
+            lora_target_modules=["q_proj"],
+            lora_bias="none",
+            lora_exclude_modules=exclude_modules,
+        ),
+        training=SimpleNamespace(gradient_checkpointing=False),
+    )
+    return trainer
+
+
+def test_peft_still_exposes_custom_module_registration():
+    """Pinned peft must keep _register_custom_module; a pin bump must not drop it."""
+    cfg = _lora_config()
+    assert hasattr(cfg, "_register_custom_module")
+
+
+def test_stock_get_peft_model_rejects_gemma4_clippable_linear():
+    model = _LanguageAndVision()
+    with pytest.raises(ValueError, match="Gemma4ClippableLinear"):
+        get_peft_model(model, _lora_config())
+
+
+def test_get_peft_model_wraps_clippable_q_proj_and_trains_adapter_not_inner():
+    model = _LanguageAndVision()
+    inner_id = id(model.q_proj.linear.weight)
+    inner_weight = model.q_proj.linear.weight
+    cfg = _lora_config()
+    register_clippable_linear_lora(cfg)
+    peft_model = get_peft_model(model, cfg)
+
+    q_proj = peft_model.base_model.q_proj
+    assert isinstance(q_proj, BaseTunerLayer)
+    assert q_proj.get_base_layer().weight is inner_weight
+    assert id(q_proj.get_base_layer().weight) == inner_id
+
+    lora_params = [p for n, p in peft_model.named_parameters() if "lora_" in n]
+    assert lora_params, "expected LoRA adapter parameters on q_proj"
+    assert all(p.requires_grad for p in lora_params)
+    assert not q_proj.get_base_layer().weight.requires_grad
+
+    x = torch.randn(2, 8, requires_grad=True)
+    peft_model.train()
+    q_proj(x).sum().backward()
+    assert any(p.grad is not None and p.grad.abs().sum() > 0 for p in lora_params)
+    assert q_proj.get_base_layer().weight.grad is None
+
+
+def test_clipping_is_applied_around_inner_lora():
+    model = _LanguageAndVision()
+    model.q_proj.input_min.fill_(0.0)
+    model.q_proj.input_max.fill_(0.0)
+    cfg = _lora_config()
+    register_clippable_linear_lora(cfg)
+    peft_model = get_peft_model(model, cfg)
+    out = peft_model.base_model.q_proj(torch.ones(2, 8))
+    assert torch.allclose(out, torch.zeros_like(out), atol=1e-6)
+
+
+def test_apply_lora_keeps_vision_tower_exclude():
+    trainer = _trainer_for_lora(exclude_modules=r"(.*\.)?vision_tower\..*")
+    model = trainer.apply_lora_to_model(_LanguageAndVision())
+
+    assert isinstance(model.base_model.q_proj, BaseTunerLayer)
+    vision_q = model.base_model.vision_tower.q_proj
+    assert isinstance(vision_q, Gemma4ClippableLinear)
+    assert not isinstance(vision_q, BaseTunerLayer)
+    assert not any("vision_tower" in n and "lora_" in n for n, _ in model.named_parameters())
+
+
+def test_plain_nn_linear_q_proj_unchanged():
+    trainer = _trainer_for_lora()
+    model = trainer.apply_lora_to_model(_PlainLinearLM())
+    q_proj = model.base_model.q_proj
+    assert isinstance(q_proj, BaseTunerLayer)
+    assert isinstance(q_proj.get_base_layer(), nn.Linear)
+    lora_params = [p for n, p in model.named_parameters() if "lora_" in n]
+    assert lora_params
+    assert all(p.requires_grad for p in lora_params)
+    assert not q_proj.get_base_layer().weight.requires_grad
+
+
+def test_qlora_loaded_in_4bit_is_forwarded_to_inner_linear(monkeypatch):
+    """QLoRA dispatch sees the inner nn.Linear/Linear4bit, not the clip wrapper."""
+    from peft.tuners.lora.model import LoraModel
+
+    orig = LoraModel._create_new_module
+    inner_calls = []
+
+    def spy(config, adapter_name, target, **kwargs):
+        inner_calls.append((target, kwargs.get("loaded_in_4bit")))
+        return orig(config, adapter_name, target, **kwargs)
+
+    monkeypatch.setattr(LoraModel, "_create_new_module", staticmethod(spy))
+    model = _LanguageAndVision()
+    model.is_loaded_in_4bit = True
+    cfg = _lora_config()
+    register_clippable_linear_lora(cfg)
+    get_peft_model(model, cfg)
+
+    assert any(isinstance(target, Gemma4ClippableLinear) for target, _ in inner_calls)
+    assert any(
+        isinstance(target, nn.Linear) and loaded_in_4bit is True
+        for target, loaded_in_4bit in inner_calls
+    )
+
+
+def test_failed_inner_dispatch_restores_custom_modules(monkeypatch):
+    from peft.tuners.lora.model import LoraModel
+
+    orig = LoraModel._create_new_module
+    cfg = _lora_config()
+    register_clippable_linear_lora(cfg)
+    mapping = cfg._custom_modules
+
+    def spy(config, adapter_name, target, **kwargs):
+        if isinstance(target, nn.Linear):
+            raise RuntimeError("dispatch failed")
+        return orig(config, adapter_name, target, **kwargs)
+
+    monkeypatch.setattr(LoraModel, "_create_new_module", staticmethod(spy))
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        get_peft_model(_LanguageAndVision(), cfg)
+    assert cfg._custom_modules is mapping
+
+
+def test_peft_model_from_pretrained_reregisters_custom_modules(monkeypatch):
+    captured = {}
+
+    def fake_from_pretrained(model, model_id, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return model
+
+    monkeypatch.setattr("peft.PeftModel.from_pretrained", fake_from_pretrained)
+    monkeypatch.setattr("peft.PeftConfig.from_pretrained", lambda _id: _lora_config())
+
+    dummy = _LanguageAndVision()
+    peft_model_from_pretrained(dummy, "unused-adapter")
+    config = captured["config"]
+    assert config is not None
+    assert config._custom_modules
+    assert Gemma4ClippableLinear in config._custom_modules

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -98,11 +98,10 @@ class SFTVLMTrainer(BaseTrainer):
             frozen_tower_attr = self._freeze_vision_tower(self.model)
 
         # Keep LoRA out of the (frozen) vision tower. target_modules like q_proj
-        # match by name across the whole model, so without this PEFT tries to
-        # adapt the vision tower's attention -- whose projections are custom
-        # module types (e.g. Gemma4's Gemma4ClippableLinear) that PEFT can't wrap,
-        # raising "Target module ... is not supported". A regex string exclusion
-        # is required because a list only suffix-matches leaf names, not a subtree.
+        # match by name across the whole model, including the tower. FAI-RL can
+        # wrap Gemma4ClippableLinear, so exclusion is what actually keeps the
+        # frozen tower unadapted -- not a PEFT type error. A regex string is
+        # required because a list only suffix-matches leaf names, not a subtree.
         if (
             getattr(self.config.model, "use_lora", False)
             and frozen_tower_attr is not None


### PR DESCRIPTION
## Summary

PEFT rejects the Gemma4 E-series clip wrapper (`Gemma4ClippableLinear`) as a LoRA
target even when `q_proj` names match, so language LoRA silently dropped those
targets. This registers a custom PEFT module that adapts the wrapper's inner
`.linear` (including QLoRA 4-bit dispatch), so LoRA trains the real linear while
the clip behavior is preserved — without dropping targets or replacing the wrapper.

## Changes

- `core/peft_lora.py`: register a custom module mapping `Gemma4ClippableLinear` to a
  LoRA adapter on its inner `.linear`; restore custom-module registration on failed
  inner dispatch and on `PeftModel.from_pretrained`.
- `core/config.py`, `core/trainer_base.py`, `trainers/sft_vlm_trainer.py`,
  `inference/inference.py`: wire the custom registration through the LoRA setup and
  inference paths.
- `tests/test_clippable_linear_lora.py`: new test coverage.

## Testing

New unit tests in `tests/test_clippable_linear_lora.py` (11 tests) cover:

- PEFT still exposes custom-module registration, and stock `get_peft_model` rejects
  `Gemma4ClippableLinear`.
- `get_peft_model` wraps the clippable `q_proj` and trains the adapter, not the inner linear.
- Clipping is applied around the inner LoRA.
- Vision tower stays excluded; plain `nn.Linear` `q_proj` is unchanged.
- QLoRA loaded in 4-bit is forwarded to the inner linear.
- Failed inner dispatch restores custom modules; `PeftModel.from_pretrained`
  re-registers them.
