### PR TITLE
fix(gemma4): freeze and LoRA-exclude unused encoders on all SFT paths

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -41,10 +41,10 @@ class ModelConfig:
     lora_dropout: float = 0.05
     lora_target_modules: Optional[List[str]] = None
     # Module name patterns to exclude from LoRA injection even if they match
-    # lora_target_modules. Needed for VLMs, where the (frozen) vision tower has
-    # attention projections named like the language model's (q_proj/k_proj/...).
-    # The sft_vlm trainer auto-populates this with the vision tower when
-    # freeze_vision_tower is set and no explicit list is given.
+    # lora_target_modules. Needed for multimodal backbones, where unused/frozen
+    # vision and audio towers can have projections named like the language
+    # model's (q_proj/k_proj/...). SFT and DPO trainers merge unused encoder
+    # subtrees into this setting before adapter injection.
     #
     # A list matches leaf module names (suffix match); a single string is treated
     # by PEFT as a regex full-matched against the whole module path, which is what
@@ -52,10 +52,9 @@ class ModelConfig:
     lora_exclude_modules: Optional[Union[str, List[str]]] = None
     lora_bias: str = "none"
 
-    # Multimodal (vision-language) configuration. Only used by the sft_vlm
-    # algorithm. When True, the vision encoder is frozen and only the language
-    # model / projector (and LoRA adapters, if enabled) are trained -- the
-    # standard recipe for VLM SFT.
+    # Multimodal (vision-language) configuration. When True in sft_vlm, the
+    # vision encoder is frozen even when the collator feeds images/videos. Text
+    # SFT/DPO always freeze unused vision and audio encoders independently.
     freeze_vision_tower: bool = True
 
     def to_dict(self) -> Dict[str, Any]:

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -775,8 +775,31 @@ class BaseTrainer(ABC):
                     model, self._AUDIO_UNUSED_ATTRS, "audio"
                 )
             )
+        # Remember the frozen leaf attrs so a later PEFT-adapter resume can
+        # re-freeze the same subtrees (the exclusion regex only governs fresh
+        # LoRA injection, not adapters reloaded from a checkpoint).
+        self._frozen_encoder_attrs = sorted(
+            {path.rsplit(".", 1)[-1] for path in frozen_paths}
+        )
         self._add_lora_subtree_exclusions(frozen_paths)
         return model
+
+    def _refreeze_frozen_encoder_subtrees(self, model) -> None:
+        """Re-freeze encoder subtrees after resuming a PEFT adapter.
+
+        ``prepare_model_for_modalities`` froze the base towers and set an
+        exclude_modules regex, but that regex only governs *fresh* LoRA
+        injection via ``get_peft_model``. Resuming with
+        ``peft_model_from_pretrained(..., is_trainable=True)`` reloads whatever
+        adapters the checkpoint holds -- including any inside the towers from a
+        pre-fix run -- and marks them trainable, reproducing the DDP
+        unused-parameter failure. Freezing the same subtrees again drops those
+        reloaded adapters back out of the gradient graph.
+        """
+        attrs = getattr(self, "_frozen_encoder_attrs", None)
+        if not attrs:
+            return
+        self._freeze_named_encoder_subtrees(model, attrs, "resumed")
 
     def apply_lora_to_model(self, model, task_type: TaskType = TaskType.CAUSAL_LM,
                             quantization_config: Optional[BitsAndBytesConfig] = None):
@@ -800,6 +823,10 @@ class BaseTrainer(ABC):
         if peft_adapter_path is not None:
             self.logger.info("Loading existing PEFT adapter from %s", peft_adapter_path)
             model = peft_model_from_pretrained(model, peft_adapter_path, is_trainable=True)
+            # A checkpoint from before the modality fix may carry adapters inside
+            # the frozen vision/audio towers; re-freeze them so DDP does not see
+            # trainable-but-unused parameters.
+            self._refreeze_frozen_encoder_subtrees(model)
             trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
             total_params = sum(p.numel() for p in model.parameters())
             self.logger.info(

--- a/core/trainer_base.py
+++ b/core/trainer_base.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os, sys
 import logging
+import re
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any, TYPE_CHECKING
+from typing import Optional, Dict, Any, TYPE_CHECKING, Iterable
 
 # Workaround for a bug in transformers where build_peft_weight_mapping passes
 # distributed_operation/quantization_operation as constructor kwargs to
@@ -152,6 +153,13 @@ from utils.device_utils import (
 
 class BaseTrainer(ABC):
     """Abstract base class for all trainers."""
+
+    _VISION_ENCODER_ATTRS = ("visual", "vision_tower", "vision_model")
+    _AUDIO_ENCODER_ATTRS = ("audio_tower", "audio_model", "audio_encoder")
+    # Gemma 4 keeps modality-to-language projection blocks outside each tower.
+    # They are also skipped entirely when that modality is absent.
+    _VISION_UNUSED_ATTRS = _VISION_ENCODER_ATTRS + ("embed_vision",)
+    _AUDIO_UNUSED_ATTRS = _AUDIO_ENCODER_ATTRS + ("embed_audio",)
 
     # Auto class used to load the base model. Text trainers use
     # AutoModelForCausalLM (the default); the multimodal trainer overrides this
@@ -679,6 +687,96 @@ class BaseTrainer(ABC):
             return self._auto_model_class.from_pretrained(base_model_path, **clean_kwargs)
 
         return self._auto_model_class.from_pretrained(model_path, **model_kwargs)
+
+    @staticmethod
+    def _exclude_patterns_as_regex(patterns) -> Optional[str]:
+        """Preserve PEFT's string-regex and list-suffix exclusion semantics."""
+        if not patterns:
+            return None
+        if isinstance(patterns, str):
+            return patterns
+        return "|".join(
+            rf"(?:.*\.)?{re.escape(name)}"
+            for name in patterns
+        )
+
+    def _freeze_named_encoder_subtrees(
+        self, model, encoder_attrs: Iterable[str], modality: str
+    ) -> list[str]:
+        """Freeze every matching encoder subtree and return its module path."""
+        attrs = set(encoder_attrs)
+        found = []
+        for path, module in model.named_modules():
+            if not path or path.rsplit(".", 1)[-1] not in attrs:
+                continue
+            # A nested match is already covered by its matched parent.
+            if any(path.startswith(f"{parent}.") for parent in found):
+                continue
+            if not hasattr(module, "parameters"):
+                continue
+            for parameter in module.parameters():
+                parameter.requires_grad_(False)
+            found.append(path)
+            self.logger.info(f"Froze {modality} encoder: {path}")
+        return found
+
+    def _add_lora_subtree_exclusions(self, module_paths: Iterable[str]) -> None:
+        """Merge frozen subtree paths into PEFT's exclusion regex."""
+        if not getattr(self.config.model, "use_lora", False):
+            return
+
+        attrs = sorted({path.rsplit(".", 1)[-1] for path in module_paths})
+        if not attrs:
+            return
+        frozen_regex = "|".join(
+            rf"(?:.*\.)?{re.escape(attr)}(?:\..*)?" for attr in attrs
+        )
+        existing = self._exclude_patterns_as_regex(
+            getattr(self.config.model, "lora_exclude_modules", None)
+        )
+        combined = rf"(?:{existing})|(?:{frozen_regex})" if existing else frozen_regex
+        self.config.model.lora_exclude_modules = combined
+        self.logger.info(
+            f"Excluding frozen encoder subtrees from LoRA injection: {combined!r}"
+        )
+
+    def prepare_model_for_modalities(
+        self,
+        model,
+        *,
+        use_vision: bool,
+        use_audio: bool,
+        freeze_vision: bool = False,
+    ):
+        """Freeze and LoRA-exclude encoders the run's collator will not feed.
+
+        ``freeze_vision`` is the explicit VLM recipe override: it freezes vision
+        even when image/video inputs are present. Audio is otherwise frozen only
+        when the collator does not supply audio inputs.
+        """
+        frozen_paths = []
+        if not use_vision:
+            frozen_paths.extend(
+                self._freeze_named_encoder_subtrees(
+                    model, self._VISION_UNUSED_ATTRS, "vision"
+                )
+            )
+        elif freeze_vision:
+            # Keep the active modality projector trainable; only the explicit
+            # recipe's encoder-freeze behavior applies when vision is in use.
+            frozen_paths.extend(
+                self._freeze_named_encoder_subtrees(
+                    model, self._VISION_ENCODER_ATTRS, "vision"
+                )
+            )
+        if not use_audio:
+            frozen_paths.extend(
+                self._freeze_named_encoder_subtrees(
+                    model, self._AUDIO_UNUSED_ATTRS, "audio"
+                )
+            )
+        self._add_lora_subtree_exclusions(frozen_paths)
+        return model
 
     def apply_lora_to_model(self, model, task_type: TaskType = TaskType.CAUSAL_LM,
                             quantization_config: Optional[BitsAndBytesConfig] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FAI-RL"
-version = "0.2.10"
+version = "0.2.11"
 description = "Foundation of AI - Reinforcement learning Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_clippable_linear_lora.py
+++ b/tests/test_clippable_linear_lora.py
@@ -266,6 +266,45 @@ def test_image_only_respects_explicit_freeze_vision_recipe():
     assert not any(p.requires_grad for p in model.model.embed_audio.parameters())
 
 
+def test_resume_refreezes_adapters_left_inside_encoder_towers(monkeypatch):
+    """A pre-fix checkpoint can carry LoRA adapters inside the vision/audio
+    towers. Resuming it with is_trainable=True would re-enable those unused
+    adapters and crash DDP; the resume path must re-freeze the towers."""
+    # Build an "old checkpoint": LoRA injected with NO exclusion, so trainable
+    # adapters land in every q_proj -- including the towers.
+    cfg = _lora_config()
+    register_clippable_linear_lora(cfg)
+    old_ckpt = get_peft_model(_Gemma4LikeMultimodal(), cfg)
+    assert any(
+        ("vision_tower" in n or "audio_tower" in n) and "lora_" in n and p.requires_grad
+        for n, p in old_ckpt.named_parameters()
+    ), "fixture should start with trainable tower adapters"
+
+    trainer = _trainer_for_lora()
+    trainer._peft_adapter_path = "unused-adapter-dir"
+    monkeypatch.setattr(
+        "core.trainer_base.peft_model_from_pretrained",
+        lambda model, path, **kwargs: old_ckpt,
+    )
+
+    # The freeze pass records which encoder subtrees to keep frozen on resume.
+    base = _Gemma4LikeMultimodal()
+    trainer.prepare_model_for_modalities(base, use_vision=False, use_audio=False)
+
+    resumed = trainer.apply_lora_to_model(base)
+
+    tower_adapters = [
+        p for n, p in resumed.named_parameters()
+        if ("vision_tower" in n or "audio_tower" in n) and "lora_" in n
+    ]
+    language_adapters = [
+        p for n, p in resumed.named_parameters()
+        if "language_model" in n and "lora_" in n
+    ]
+    assert tower_adapters and not any(p.requires_grad for p in tower_adapters)
+    assert language_adapters and all(p.requires_grad for p in language_adapters)
+
+
 def test_qlora_loaded_in_4bit_is_forwarded_to_inner_linear(monkeypatch):
     """QLoRA dispatch sees the inner nn.Linear/Linear4bit, not the clip wrapper."""
     from peft.tuners.lora.model import LoraModel

--- a/tests/test_clippable_linear_lora.py
+++ b/tests/test_clippable_linear_lora.py
@@ -66,6 +66,28 @@ class _PlainLinearLM(nn.Module):
     prepare_inputs_for_generation = _prepare_inputs_for_generation
 
 
+class _Gemma4LikeMultimodal(nn.Module):
+    """Tiny Gemma 4 E-series-shaped model used to exercise modality pruning."""
+
+    def __init__(self, hidden=8):
+        super().__init__()
+        cfg = _ClipCfg()
+        self.model = nn.Module()
+        self.model.language_model = nn.Module()
+        self.model.language_model.q_proj = Gemma4ClippableLinear(cfg, hidden, hidden)
+        self.model.vision_tower = nn.Module()
+        self.model.vision_tower.q_proj = Gemma4ClippableLinear(cfg, hidden, hidden)
+        self.model.embed_vision = nn.Linear(hidden, hidden, bias=False)
+        self.model.audio_tower = nn.Module()
+        self.model.audio_tower.q_proj = Gemma4ClippableLinear(cfg, hidden, hidden)
+        self.model.embed_audio = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, x):
+        return self.model.language_model.q_proj(x)
+
+    prepare_inputs_for_generation = _prepare_inputs_for_generation
+
+
 def _lora_config(**extra):
     kwargs = dict(
         r=4,
@@ -169,6 +191,79 @@ def test_plain_nn_linear_q_proj_unchanged():
     assert lora_params
     assert all(p.requires_grad for p in lora_params)
     assert not q_proj.get_base_layer().weight.requires_grad
+
+
+def test_text_only_qwen_like_model_is_unchanged_by_modality_prep():
+    """Qwen3-8B-class CausalLMs have no vision/audio towers; freeze is a no-op."""
+    trainer = _trainer_for_lora()
+    model = _PlainLinearLM()
+    before = {n: p.requires_grad for n, p in model.named_parameters()}
+
+    trainer.prepare_model_for_modalities(model, use_vision=False, use_audio=False)
+
+    after = {n: p.requires_grad for n, p in model.named_parameters()}
+    assert after == before
+    assert trainer.config.model.lora_exclude_modules is None
+
+    peft_model = trainer.apply_lora_to_model(model)
+    q_proj = peft_model.base_model.q_proj
+    assert isinstance(q_proj, BaseTunerLayer)
+    assert isinstance(q_proj.get_base_layer(), nn.Linear)
+
+
+def test_text_only_freezes_and_excludes_gemma4_vision_and_audio():
+    trainer = _trainer_for_lora()
+    model = _Gemma4LikeMultimodal()
+
+    trainer.prepare_model_for_modalities(model, use_vision=False, use_audio=False)
+
+    assert not any(p.requires_grad for p in model.model.vision_tower.parameters())
+    assert not any(p.requires_grad for p in model.model.embed_vision.parameters())
+    assert not any(p.requires_grad for p in model.model.audio_tower.parameters())
+    assert not any(p.requires_grad for p in model.model.embed_audio.parameters())
+    assert all(p.requires_grad for p in model.model.language_model.parameters())
+
+    peft_model = trainer.apply_lora_to_model(model)
+    base = peft_model.base_model.model.model
+    assert isinstance(base.language_model.q_proj, BaseTunerLayer)
+    assert isinstance(base.vision_tower.q_proj, Gemma4ClippableLinear)
+    assert isinstance(base.audio_tower.q_proj, Gemma4ClippableLinear)
+    assert not any(
+        ("vision_tower" in name or "audio_tower" in name) and "lora_" in name
+        for name, _ in peft_model.named_parameters()
+    )
+
+
+def test_image_only_keeps_vision_trainable_but_freezes_and_excludes_audio():
+    trainer = _trainer_for_lora()
+    model = _Gemma4LikeMultimodal()
+
+    trainer.prepare_model_for_modalities(model, use_vision=True, use_audio=False)
+
+    assert all(p.requires_grad for p in model.model.vision_tower.parameters())
+    assert all(p.requires_grad for p in model.model.embed_vision.parameters())
+    assert not any(p.requires_grad for p in model.model.audio_tower.parameters())
+    assert not any(p.requires_grad for p in model.model.embed_audio.parameters())
+
+    peft_model = trainer.apply_lora_to_model(model)
+    base = peft_model.base_model.model.model
+    assert isinstance(base.language_model.q_proj, BaseTunerLayer)
+    assert isinstance(base.vision_tower.q_proj, BaseTunerLayer)
+    assert isinstance(base.audio_tower.q_proj, Gemma4ClippableLinear)
+
+
+def test_image_only_respects_explicit_freeze_vision_recipe():
+    trainer = _trainer_for_lora()
+    model = _Gemma4LikeMultimodal()
+
+    trainer.prepare_model_for_modalities(
+        model, use_vision=True, use_audio=False, freeze_vision=True
+    )
+
+    assert not any(p.requires_grad for p in model.model.vision_tower.parameters())
+    assert all(p.requires_grad for p in model.model.embed_vision.parameters())
+    assert not any(p.requires_grad for p in model.model.audio_tower.parameters())
+    assert not any(p.requires_grad for p in model.model.embed_audio.parameters())
 
 
 def test_qlora_loaded_in_4bit_is_forwarded_to_inner_linear(monkeypatch):

--- a/tests/test_modality_setup_order.py
+++ b/tests/test_modality_setup_order.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import torch.nn as nn
 
+from trainers.cpt_trainer import CPTTrainer
 from trainers.dpo_trainer import DPOTrainer
 from trainers.sft_trainer import SFTTrainer
 from trainers.sft_vlm_trainer import SFTVLMTrainer
@@ -24,6 +25,25 @@ def _text_trainer_setup(trainer_cls):
 
 def test_text_sft_prepares_text_only_modalities_before_lora():
     trainer = _text_trainer_setup(SFTTrainer)
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {"use_vision": False, "use_audio": False},
+    )
+    assert calls[1][0] == "lora"
+
+
+def test_cpt_prepares_text_only_modalities_before_lora():
+    trainer = _text_trainer_setup(CPTTrainer)
     calls = []
     trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
         ("modalities", kwargs)

--- a/tests/test_modality_setup_order.py
+++ b/tests/test_modality_setup_order.py
@@ -1,0 +1,104 @@
+import logging
+from types import SimpleNamespace
+
+import torch.nn as nn
+
+from trainers.dpo_trainer import DPOTrainer
+from trainers.sft_trainer import SFTTrainer
+from trainers.sft_vlm_trainer import SFTVLMTrainer
+
+
+def _text_trainer_setup(trainer_cls):
+    trainer = object.__new__(trainer_cls)
+    trainer.logger = logging.getLogger(f"test_{trainer_cls.__name__}")
+    trainer.config = SimpleNamespace(model=SimpleNamespace(base_model_name="unused", use_lora=True))
+    trainer.model = None
+    trainer.ref_model = None
+    trainer.create_quantization_config = lambda: None
+    trainer.prepare_model_kwargs = lambda _quantization: {}
+    trainer.load_base_model_for_training = lambda _kwargs: nn.Module()
+    trainer.setup_tokenizer_with_model = lambda _model: SimpleNamespace()
+    trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
+    return trainer
+
+
+def test_text_sft_prepares_text_only_modalities_before_lora():
+    trainer = _text_trainer_setup(SFTTrainer)
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {"use_vision": False, "use_audio": False},
+    )
+    assert calls[1][0] == "lora"
+
+
+def test_dpo_prepares_text_only_modalities_before_lora():
+    trainer = _text_trainer_setup(DPOTrainer)
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {"use_vision": False, "use_audio": False},
+    )
+    assert calls[1][0] == "lora"
+
+
+def test_vlm_image_collator_keeps_vision_and_prepares_before_lora(monkeypatch):
+    tokenizer = SimpleNamespace(pad_token="pad", eos_token="eos")
+    monkeypatch.setattr(
+        "trainers.sft_vlm_trainer.AutoProcessor.from_pretrained",
+        lambda *_args, **_kwargs: SimpleNamespace(tokenizer=tokenizer),
+    )
+
+    trainer = object.__new__(SFTVLMTrainer)
+    trainer.logger = logging.getLogger("test_SFTVLMTrainer")
+    trainer.config = SimpleNamespace(
+        model=SimpleNamespace(
+            base_model_name="unused",
+            use_lora=True,
+            freeze_vision_tower=False,
+        ),
+        data=SimpleNamespace(
+            datasets=[SimpleNamespace(image_columns=["image"], video_columns=None)]
+        ),
+    )
+    trainer.create_quantization_config = lambda: None
+    trainer.prepare_model_kwargs = lambda _quantization: {}
+    trainer.load_base_model_for_training = lambda _kwargs: nn.Module()
+    trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {
+            "use_vision": True,
+            "use_audio": False,
+            "freeze_vision": False,
+        },
+    )
+    assert calls[1][0] == "lora"

--- a/tests/test_modality_setup_order.py
+++ b/tests/test_modality_setup_order.py
@@ -5,6 +5,8 @@ import torch.nn as nn
 
 from trainers.cpt_trainer import CPTTrainer
 from trainers.dpo_trainer import DPOTrainer
+from trainers.grpo_trainer import GRPOTrainer
+from trainers.gspo_trainer import GSPOTrainer
 from trainers.sft_trainer import SFTTrainer
 from trainers.sft_vlm_trainer import SFTVLMTrainer
 
@@ -44,6 +46,49 @@ def test_text_sft_prepares_text_only_modalities_before_lora():
 
 def test_cpt_prepares_text_only_modalities_before_lora():
     trainer = _text_trainer_setup(CPTTrainer)
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {"use_vision": False, "use_audio": False},
+    )
+    assert calls[1][0] == "lora"
+
+
+def test_grpo_prepares_text_only_modalities_before_lora():
+    trainer = _text_trainer_setup(GRPOTrainer)
+    calls = []
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
+        ("modalities", kwargs)
+    )
+    trainer.apply_lora_to_model = lambda model, *args, **kwargs: (
+        calls.append(("lora", kwargs)) or model
+    )
+
+    trainer.setup_model()
+
+    assert calls[0] == (
+        "modalities",
+        {"use_vision": False, "use_audio": False},
+    )
+    assert calls[1][0] == "lora"
+
+
+def test_gspo_prepares_text_only_modalities_before_lora(monkeypatch):
+    # GSPO loads via AutoModelForCausalLM directly (not load_base_model_for_training).
+    monkeypatch.setattr(
+        "trainers.gspo_trainer.AutoModelForCausalLM.from_pretrained",
+        lambda *_args, **_kwargs: nn.Module(),
+    )
+    trainer = _text_trainer_setup(GSPOTrainer)
     calls = []
     trainer.prepare_model_for_modalities = lambda model, **kwargs: calls.append(
         ("modalities", kwargs)

--- a/tests/test_peft_checkpoint_resume.py
+++ b/tests/test_peft_checkpoint_resume.py
@@ -146,6 +146,7 @@ def test_dpo_reference_model_loads_from_peft_base(monkeypatch):
     trainer.create_quantization_config = lambda: None
     trainer.prepare_model_kwargs = lambda _quantization: {}
     trainer.load_base_model_for_training = fake_load
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: model
     trainer.apply_lora_to_model = lambda model, *args, **kwargs: model
     trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
 

--- a/tests/test_sft_vlm_trainer.py
+++ b/tests/test_sft_vlm_trainer.py
@@ -99,7 +99,8 @@ def test_setup_model_loads_processor_from_peft_base_not_adapter_dir(tmp_path, mo
             base_model_name=str(adapter_dir),
             freeze_vision_tower=False,
             use_lora=False,
-        )
+        ),
+        data=SimpleNamespace(datasets=[]),
     )
 
     def fake_load(_kwargs):
@@ -110,6 +111,7 @@ def test_setup_model_loads_processor_from_peft_base_not_adapter_dir(tmp_path, mo
     trainer.create_quantization_config = lambda: None
     trainer.prepare_model_kwargs = lambda _q: {}
     trainer.load_base_model_for_training = fake_load
+    trainer.prepare_model_for_modalities = lambda model, **kwargs: model
     trainer.apply_lora_to_model = lambda model, *args, **kwargs: model
     trainer.disable_cache_for_gradient_checkpointing = lambda _model: None
 

--- a/trainers/cpt_trainer.py
+++ b/trainers/cpt_trainer.py
@@ -37,6 +37,13 @@ class CPTTrainer(BaseTrainer):
         self.model = self.load_base_model_for_training(model_kwargs)
 
         self.tokenizer = self.setup_tokenizer_with_model(self.model)
+
+        # CPT feeds raw text only -- no pixels or audio features. Gemma 4
+        # E-series still loads both encoders, so freeze and LoRA-exclude them
+        # before adapter injection to keep plain DDP from seeing unused adapters.
+        self.prepare_model_for_modalities(
+            self.model, use_vision=False, use_audio=False
+        )
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
         self.disable_cache_for_gradient_checkpointing(self.model)
 

--- a/trainers/dpo_trainer.py
+++ b/trainers/dpo_trainer.py
@@ -61,6 +61,13 @@ class DPOTrainer(BaseTrainer):
         if self.ref_model is not None:
             self.ref_model.resize_token_embeddings(len(self.tokenizer))
 
+        # DPO's text collator does not feed either multimodal encoder. Prepare
+        # the main model before LoRA so Gemma 4 E-series does not receive
+        # trainable adapters in towers that cannot contribute to the loss.
+        self.prepare_model_for_modalities(
+            self.model, use_vision=False, use_audio=False
+        )
+
         # Apply LoRA if enabled (including QLoRA) using base class method
         # Note: Only apply LoRA to the main model, not the reference model
         # The reference model should remain frozen as a baseline

--- a/trainers/grpo_trainer.py
+++ b/trainers/grpo_trainer.py
@@ -44,6 +44,14 @@ class GRPOTrainer(BaseTrainer):
         # Setup tokenizer and resize embeddings using base class method
         self.tokenizer = self.setup_tokenizer_with_model(self.model)
 
+        # GRPO trains on text prompts/completions only -- no image or audio
+        # inputs. Freeze and LoRA-exclude Gemma 4 E-series' unused vision/audio
+        # encoders before adapter injection so plain DDP does not see unused
+        # adapters.
+        self.prepare_model_for_modalities(
+            self.model, use_vision=False, use_audio=False
+        )
+
         # Apply LoRA if enabled (including QLoRA) using base class method
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
 

--- a/trainers/gspo_trainer.py
+++ b/trainers/gspo_trainer.py
@@ -49,6 +49,14 @@ class GSPOTrainer(BaseTrainer):
         # Setup tokenizer and resize embeddings using base class method
         self.tokenizer = self.setup_tokenizer_with_model(self.model)
 
+        # GSPO trains on text prompts/completions only -- no image or audio
+        # inputs. Freeze and LoRA-exclude Gemma 4 E-series' unused vision/audio
+        # encoders before adapter injection so plain DDP does not see unused
+        # adapters.
+        self.prepare_model_for_modalities(
+            self.model, use_vision=False, use_audio=False
+        )
+
         # Apply LoRA if enabled (including QLoRA) using base class method
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
 

--- a/trainers/sft_trainer.py
+++ b/trainers/sft_trainer.py
@@ -42,6 +42,13 @@ class SFTTrainer(BaseTrainer):
         # Setup tokenizer and resize embeddings using base class method
         self.tokenizer = self.setup_tokenizer_with_model(self.model)
 
+        # The text collator supplies neither pixels nor audio features. Gemma 4
+        # E-series still loads both encoders, so freeze and LoRA-exclude them
+        # before adapter injection to keep plain DDP from seeing unused adapters.
+        self.prepare_model_for_modalities(
+            self.model, use_vision=False, use_audio=False
+        )
+
         # Apply LoRA if enabled (including QLoRA) using base class method
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
 

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -19,12 +19,6 @@ from utils.video_utils import fetch_video
 from trainers.vlm_collator import VideoAwareVLMCollator
 
 
-# Submodule attribute names commonly used for the vision encoder across VLM
-# architectures (Qwen-VL exposes it as `.visual`; LLaVA/others as
-# `.vision_tower`/`.vision_model`). We freeze whichever is present.
-_VISION_TOWER_ATTRS = ("visual", "vision_tower", "vision_model")
-
-
 class SFTVLMTrainer(BaseTrainer):
     """Multimodal SFT trainer for vision-language models (image + text).
 
@@ -91,27 +85,16 @@ class SFTVLMTrainer(BaseTrainer):
         if getattr(tokenizer, "pad_token", None) is None and getattr(tokenizer, "eos_token", None):
             tokenizer.pad_token = tokenizer.eos_token
 
-        # Optionally freeze the vision encoder (standard for VLM SFT; also avoids
-        # training the ViT under full fine-tuning).
-        frozen_tower_attr = None
-        if getattr(self.config.model, "freeze_vision_tower", True):
-            frozen_tower_attr = self._freeze_vision_tower(self.model)
-
-        # Keep LoRA out of the (frozen) vision tower. target_modules like q_proj
-        # match by name across the whole model, including the tower. FAI-RL can
-        # wrap Gemma4ClippableLinear, so exclusion is what actually keeps the
-        # frozen tower unadapted -- not a PEFT type error. A regex string is
-        # required because a list only suffix-matches leaf names, not a subtree.
-        if (
-            getattr(self.config.model, "use_lora", False)
-            and frozen_tower_attr is not None
-            and not getattr(self.config.model, "lora_exclude_modules", None)
-        ):
-            self.config.model.lora_exclude_modules = rf"(.*\.)?{frozen_tower_attr}\..*"
-            self.logger.info(
-                "Excluding frozen vision tower from LoRA injection: "
-                f"lora_exclude_modules={self.config.model.lora_exclude_modules!r}"
-            )
+        # This collator feeds image/video inputs but has no audio path. Freeze
+        # every encoder it will not use before LoRA injection. The explicit
+        # freeze_vision_tower recipe setting still overrides an active vision
+        # modality, preserving the standard frozen-ViT recipe.
+        self.prepare_model_for_modalities(
+            self.model,
+            use_vision=self._has_vision_columns,
+            use_audio=False,
+            freeze_vision=getattr(self.config.model, "freeze_vision_tower", True),
+        )
 
         # Apply LoRA/QLoRA if enabled (reuses BaseTrainer helper).
         self.model = self.apply_lora_to_model(self.model, TaskType.CAUSAL_LM, quantization_config)
@@ -119,30 +102,6 @@ class SFTVLMTrainer(BaseTrainer):
         self.disable_cache_for_gradient_checkpointing(self.model)
 
         self.logger.info("VLM and processor loaded successfully")
-
-    def _freeze_vision_tower(self, model):
-        """Freeze the vision encoder submodule if one can be located.
-
-        Returns the attribute name of the frozen tower (e.g. "vision_tower"), or
-        None if no known vision submodule was found. Callers use the name to keep
-        LoRA from being injected into the frozen tower.
-        """
-        # PEFT may wrap the model; reach through to the underlying module.
-        base = getattr(model, "base_model", model)
-        base = getattr(base, "model", base)
-        for root in (model, base):
-            for attr in _VISION_TOWER_ATTRS:
-                tower = getattr(root, attr, None)
-                if tower is not None and hasattr(tower, "parameters"):
-                    for p in tower.parameters():
-                        p.requires_grad_(False)
-                    self.logger.info(f"Froze vision tower: {attr}")
-                    return attr
-        self.logger.warning(
-            "freeze_vision_tower=true but no known vision submodule "
-            f"({', '.join(_VISION_TOWER_ATTRS)}) was found; nothing frozen."
-        )
-        return None
 
     # ------------------------------ data ------------------------------------
 
@@ -539,6 +498,14 @@ class SFTVLMTrainer(BaseTrainer):
             # vision collator computes loss only on the assistant completion. Flat
             # mode leaves this False (loss over the whole sequence).
             completion_only_loss=True if self._split_mode else None,
+        )
+
+    @property
+    def _has_vision_columns(self) -> bool:
+        """True when this run's VLM collator will receive images or videos."""
+        return any(
+            getattr(ds, "image_columns", None) or getattr(ds, "video_columns", None)
+            for ds in self.config.data.datasets
         )
 
     @property

--- a/trainers/sft_vlm_trainer.py
+++ b/trainers/sft_vlm_trainer.py
@@ -502,7 +502,14 @@ class SFTVLMTrainer(BaseTrainer):
 
     @property
     def _has_vision_columns(self) -> bool:
-        """True when this run's VLM collator will receive images or videos."""
+        """True when this run's VLM collator will receive images or videos.
+
+        Assumption: a declared image/video column means those inputs are
+        actually fed this run. If a recipe lists an image column but every cell
+        is empty (so the collator effectively runs text-only), vision still
+        looks "in use" here and the tower is kept trainable. We do not inspect
+        per-batch contents or freeze/unfreeze mid-run to catch that case.
+        """
         return any(
             getattr(ds, "image_columns", None) or getattr(ds, "video_columns", None)
             for ds in self.config.data.datasets


### PR DESCRIPTION
## What
Gemma 4 E-series (E2B/E4B) ship both a vision tower and an audio tower. On text and vision-only runs those encoders are never fed, so under LoRA + plain DDP they receive unused adapters and training dies with `parameters that were not used in producing loss`.

This adds a single, architecture-agnostic rule on `BaseTrainer` — **freeze and LoRA-exclude any encoder a run's collator will not feed** — and calls it from every training path before adapter injection.

## Changes
- `core/trainer_base.py`: new `prepare_model_for_modalities()` plus helpers (`_freeze_named_encoder_subtrees`, `_add_lora_subtree_exclusions`, `_exclude_patterns_as_regex`). Freezes unfed vision/audio subtrees and merges them into PEFT's `exclude_modules` regex (preserving any user-set exclusion).
- `trainers/sft_trainer.py`, `dpo_trainer.py`, `cpt_trainer.py`: freeze both towers (text collators feed neither).
- `trainers/sft_vlm_trainer.py`: replaces the old vision-only `_freeze_vision_tower` with the shared helper; `use_vision` is dynamic (images **or** video), audio always frozen. Adds `_has_vision_columns`.
- `core/config.py`: doc updates only.

## Behavior
- Text SFT/DPO/CPT → freeze vision + audio.
- Vision/video VLM run → vision trainable (video flows through the vision tower), audio frozen; `freeze_vision_tower` recipe still freezes the ViT while keeping the projector trainable.
- Text-only models (Qwen3, GLM) → no encoders found, no-op.
- Audio is intentionally never fed (product scope: vision-language only for now).

## Tests
- `test_modality_setup_order.py` (new): freeze-before-LoRA ordering for SFT, DPO, CPT, and the VLM image path.
- `test_clippable_linear_lora.py`: behavior on a Gemma-4-like tree (text-only, image-only, `freeze_vision` recipe, text-only no-op).

## Follow-up
Unblocks encoder-driven DDP unused-params. A stacked follow-up (`ddp_find_unused_parameters` gating for Gemma 4 configs) addresses residual language-model unused params from PLE / KV-sharing — tracked as TODO 2.